### PR TITLE
[docs] Change source reference in README to reflect registry source address

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can go to the [examples](./examples) folder to see all the use cases, howeve
 
 ```hcl
 module "logsink" {
-  source           = "github.com/terraform-google-modules/terraform-google-log-export"
+  source           = "terraform-google-modules/log-export/google"
   name             = "my-logsink"
   folder           = "2165468435"
   filter           = "severity >= ERROR"


### PR DESCRIPTION

This PR changes the github source referenced in the README example docs to a standard registry source address to reference the published registry module.
