### PR TITLE
Upgrade examples to 0.12

### DIFF
--- a/examples/bigquery/billing_account/main.tf
+++ b/examples/bigquery/billing_account/main.tf
@@ -20,16 +20,16 @@ provider "google" {
 
 module "log_export" {
   source                 = "../../../"
-  destination_uri        = "${module.destination.destination_uri}"
+  destination_uri        = module.destination.destination_uri
   log_sink_name          = "bigquery_example_logsink"
-  parent_resource_id     = "${var.parent_resource_id}"
+  parent_resource_id     = var.parent_resource_id
   parent_resource_type   = "billing_account"
   unique_writer_identity = "true"
 }
 
 module "destination" {
   source                   = "../../..//modules/bigquery"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   dataset_name             = "bigquery_example"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
 }

--- a/examples/bigquery/billing_account/outputs.tf
+++ b/examples/bigquery/billing_account/outputs.tf
@@ -18,11 +18,11 @@ output "log_export_map" {
   description = "Outputs from the log export module"
 
   value = {
-    filter                 = "${module.log_export.filter}"
-    log_sink_resource_id   = "${module.log_export.log_sink_resource_id}"
-    log_sink_resource_name = "${module.log_export.log_sink_resource_name}"
-    parent_resource_id     = "${module.log_export.parent_resource_id}"
-    writer_identity        = "${module.log_export.writer_identity}"
+    filter                 = module.log_export.filter
+    log_sink_resource_id   = module.log_export.log_sink_resource_id
+    log_sink_resource_name = module.log_export.log_sink_resource_name
+    parent_resource_id     = module.log_export.parent_resource_id
+    writer_identity        = module.log_export.writer_identity
   }
 }
 
@@ -30,11 +30,11 @@ output "destination_map" {
   description = "Outputs from the destination module"
 
   value = {
-    console_link    = "${module.destination.console_link}"
-    project         = "${module.destination.project}"
-    resource_name   = "${module.destination.resource_name}"
-    resource_id     = "${module.destination.resource_id}"
-    self_link       = "${module.destination.self_link}"
-    destination_uri = "${module.destination.destination_uri}"
+    console_link    = module.destination.console_link
+    project         = module.destination.project
+    resource_name   = module.destination.resource_name
+    resource_id     = module.destination.resource_id
+    self_link       = module.destination.self_link
+    destination_uri = module.destination.destination_uri
   }
 }

--- a/examples/bigquery/billing_account/versions.tf
+++ b/examples/bigquery/billing_account/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/bigquery/folder/main.tf
+++ b/examples/bigquery/folder/main.tf
@@ -26,17 +26,17 @@ resource "random_string" "suffix" {
 
 module "log_export" {
   source                 = "../../../"
-  destination_uri        = "${module.destination.destination_uri}"
+  destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "bigquery_folder_${random_string.suffix.result}"
-  parent_resource_id     = "${var.parent_resource_id}"
+  parent_resource_id     = var.parent_resource_id
   parent_resource_type   = "folder"
   unique_writer_identity = "true"
 }
 
 module "destination" {
   source                   = "../../..//modules/bigquery"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   dataset_name             = "bq_folder_${random_string.suffix.result}"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
 }

--- a/examples/bigquery/folder/outputs.tf
+++ b/examples/bigquery/folder/outputs.tf
@@ -18,11 +18,11 @@ output "log_export_map" {
   description = "Outputs from the log export module"
 
   value = {
-    filter                 = "${module.log_export.filter}"
-    log_sink_resource_id   = "${module.log_export.log_sink_resource_id}"
-    log_sink_resource_name = "${module.log_export.log_sink_resource_name}"
-    parent_resource_id     = "${module.log_export.parent_resource_id}"
-    writer_identity        = "${module.log_export.writer_identity}"
+    filter                 = module.log_export.filter
+    log_sink_resource_id   = module.log_export.log_sink_resource_id
+    log_sink_resource_name = module.log_export.log_sink_resource_name
+    parent_resource_id     = module.log_export.parent_resource_id
+    writer_identity        = module.log_export.writer_identity
   }
 }
 
@@ -30,11 +30,11 @@ output "destination_map" {
   description = "Outputs from the destination module"
 
   value = {
-    console_link    = "${module.destination.console_link}"
-    project         = "${module.destination.project}"
-    resource_name   = "${module.destination.resource_name}"
-    resource_id     = "${module.destination.resource_id}"
-    self_link       = "${module.destination.self_link}"
-    destination_uri = "${module.destination.destination_uri}"
+    console_link    = module.destination.console_link
+    project         = module.destination.project
+    resource_name   = module.destination.resource_name
+    resource_id     = module.destination.resource_id
+    self_link       = module.destination.self_link
+    destination_uri = module.destination.destination_uri
   }
 }

--- a/examples/bigquery/folder/versions.tf
+++ b/examples/bigquery/folder/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/bigquery/organization/main.tf
+++ b/examples/bigquery/organization/main.tf
@@ -26,17 +26,18 @@ resource "random_string" "suffix" {
 
 module "log_export" {
   source                 = "../../../"
-  destination_uri        = "${module.destination.destination_uri}"
+  destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "bigquery_org_${random_string.suffix.result}"
-  parent_resource_id     = "${var.parent_resource_id}"
+  parent_resource_id     = var.parent_resource_id
   parent_resource_type   = "organization"
   unique_writer_identity = "true"
 }
 
 module "destination" {
   source                   = "../../..//modules/bigquery"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   dataset_name             = "bq_org_${random_string.suffix.result}"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
 }
+

--- a/examples/bigquery/organization/outputs.tf
+++ b/examples/bigquery/organization/outputs.tf
@@ -18,11 +18,11 @@ output "log_export_map" {
   description = "Outputs from the log export module"
 
   value = {
-    filter                 = "${module.log_export.filter}"
-    log_sink_resource_id   = "${module.log_export.log_sink_resource_id}"
-    log_sink_resource_name = "${module.log_export.log_sink_resource_name}"
-    parent_resource_id     = "${module.log_export.parent_resource_id}"
-    writer_identity        = "${module.log_export.writer_identity}"
+    filter                 = module.log_export.filter
+    log_sink_resource_id   = module.log_export.log_sink_resource_id
+    log_sink_resource_name = module.log_export.log_sink_resource_name
+    parent_resource_id     = module.log_export.parent_resource_id
+    writer_identity        = module.log_export.writer_identity
   }
 }
 
@@ -30,11 +30,12 @@ output "destination_map" {
   description = "Outputs from the destination module"
 
   value = {
-    console_link    = "${module.destination.console_link}"
-    project         = "${module.destination.project}"
-    resource_name   = "${module.destination.resource_name}"
-    resource_id     = "${module.destination.resource_id}"
-    self_link       = "${module.destination.self_link}"
-    destination_uri = "${module.destination.destination_uri}"
+    console_link    = module.destination.console_link
+    project         = module.destination.project
+    resource_name   = module.destination.resource_name
+    resource_id     = module.destination.resource_id
+    self_link       = module.destination.self_link
+    destination_uri = module.destination.destination_uri
   }
 }
+

--- a/examples/bigquery/organization/variables.tf
+++ b/examples/bigquery/organization/variables.tf
@@ -21,3 +21,4 @@ variable "project_id" {
 variable "parent_resource_id" {
   description = "The ID of the project in which BigQuery dataset destination will be created."
 }
+

--- a/examples/bigquery/organization/versions.tf
+++ b/examples/bigquery/organization/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/bigquery/project/main.tf
+++ b/examples/bigquery/project/main.tf
@@ -26,17 +26,18 @@ resource "random_string" "suffix" {
 
 module "log_export" {
   source                 = "../../../"
-  destination_uri        = "${module.destination.destination_uri}"
+  destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "bigquery_project_${random_string.suffix.result}"
-  parent_resource_id     = "${var.parent_resource_id}"
+  parent_resource_id     = var.parent_resource_id
   parent_resource_type   = "project"
   unique_writer_identity = "true"
 }
 
 module "destination" {
   source                   = "../../..//modules/bigquery"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   dataset_name             = "bq_project_${random_string.suffix.result}"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
 }
+

--- a/examples/bigquery/project/outputs.tf
+++ b/examples/bigquery/project/outputs.tf
@@ -18,11 +18,11 @@ output "log_export_map" {
   description = "Outputs from the log export module"
 
   value = {
-    filter                 = "${module.log_export.filter}"
-    log_sink_resource_id   = "${module.log_export.log_sink_resource_id}"
-    log_sink_resource_name = "${module.log_export.log_sink_resource_name}"
-    parent_resource_id     = "${module.log_export.parent_resource_id}"
-    writer_identity        = "${module.log_export.writer_identity}"
+    filter                 = module.log_export.filter
+    log_sink_resource_id   = module.log_export.log_sink_resource_id
+    log_sink_resource_name = module.log_export.log_sink_resource_name
+    parent_resource_id     = module.log_export.parent_resource_id
+    writer_identity        = module.log_export.writer_identity
   }
 }
 
@@ -30,11 +30,12 @@ output "destination_map" {
   description = "Outputs from the destination module"
 
   value = {
-    console_link    = "${module.destination.console_link}"
-    project         = "${module.destination.project}"
-    resource_name   = "${module.destination.resource_name}"
-    resource_id     = "${module.destination.resource_id}"
-    self_link       = "${module.destination.self_link}"
-    destination_uri = "${module.destination.destination_uri}"
+    console_link    = module.destination.console_link
+    project         = module.destination.project
+    resource_name   = module.destination.resource_name
+    resource_id     = module.destination.resource_id
+    self_link       = module.destination.self_link
+    destination_uri = module.destination.destination_uri
   }
 }
+

--- a/examples/bigquery/project/variables.tf
+++ b/examples/bigquery/project/variables.tf
@@ -21,3 +21,4 @@ variable "project_id" {
 variable "parent_resource_id" {
   description = "The ID of the project in which BigQuery dataset destination will be created."
 }
+

--- a/examples/bigquery/project/versions.tf
+++ b/examples/bigquery/project/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/pubsub/billing_account/main.tf
+++ b/examples/pubsub/billing_account/main.tf
@@ -20,17 +20,18 @@ provider "google" {
 
 module "log_export" {
   source                 = "../../../"
-  destination_uri        = "${module.destination.destination_uri}"
+  destination_uri        = module.destination.destination_uri
   log_sink_name          = "pubsub_example_logsink"
-  parent_resource_id     = "${var.parent_resource_id}"
+  parent_resource_id     = var.parent_resource_id
   parent_resource_type   = "billing_account"
   unique_writer_identity = "true"
 }
 
 module "destination" {
   source                   = "../../..//modules/pubsub"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   topic_name               = "pubsub-example"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
   create_subscriber        = "true"
 }
+

--- a/examples/pubsub/billing_account/outputs.tf
+++ b/examples/pubsub/billing_account/outputs.tf
@@ -18,11 +18,11 @@ output "log_export_map" {
   description = "Outputs from the log export module"
 
   value = {
-    filter                 = "${module.log_export.filter}"
-    log_sink_resource_id   = "${module.log_export.log_sink_resource_id}"
-    log_sink_resource_name = "${module.log_export.log_sink_resource_name}"
-    parent_resource_id     = "${module.log_export.parent_resource_id}"
-    writer_identity        = "${module.log_export.writer_identity}"
+    filter                 = module.log_export.filter
+    log_sink_resource_id   = module.log_export.log_sink_resource_id
+    log_sink_resource_name = module.log_export.log_sink_resource_name
+    parent_resource_id     = module.log_export.parent_resource_id
+    writer_identity        = module.log_export.writer_identity
   }
 }
 
@@ -30,12 +30,13 @@ output "destination_map" {
   description = "Outputs from the destination module"
 
   value = {
-    console_link        = "${module.destination.console_link}"
-    project             = "${module.destination.project}"
-    resource_name       = "${module.destination.resource_name}"
-    resource_id         = "${module.destination.resource_id}"
-    destination_uri     = "${module.destination.destination_uri}"
-    pubsub_subscriber   = "${module.destination.pubsub_subscriber}"
-    pubsub_subscription = "${module.destination.pubsub_subscription}"
+    console_link        = module.destination.console_link
+    project             = module.destination.project
+    resource_name       = module.destination.resource_name
+    resource_id         = module.destination.resource_id
+    destination_uri     = module.destination.destination_uri
+    pubsub_subscriber   = module.destination.pubsub_subscriber
+    pubsub_subscription = module.destination.pubsub_subscription
   }
 }
+

--- a/examples/pubsub/billing_account/variables.tf
+++ b/examples/pubsub/billing_account/variables.tf
@@ -21,3 +21,4 @@ variable "project_id" {
 variable "parent_resource_id" {
   description = "The ID of the project in which pubsub topic destination will be created."
 }
+

--- a/examples/pubsub/billing_account/versions.tf
+++ b/examples/pubsub/billing_account/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/pubsub/folder/main.tf
+++ b/examples/pubsub/folder/main.tf
@@ -26,18 +26,19 @@ resource "random_string" "suffix" {
 
 module "log_export" {
   source                 = "../../../"
-  destination_uri        = "${module.destination.destination_uri}"
+  destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "pubsub_folder_${random_string.suffix.result}"
-  parent_resource_id     = "${var.parent_resource_id}"
+  parent_resource_id     = var.parent_resource_id
   parent_resource_type   = "folder"
   unique_writer_identity = "true"
 }
 
 module "destination" {
   source                   = "../../..//modules/pubsub"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   topic_name               = "pubsub-folder-${random_string.suffix.result}"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
   create_subscriber        = "true"
 }
+

--- a/examples/pubsub/folder/outputs.tf
+++ b/examples/pubsub/folder/outputs.tf
@@ -18,11 +18,11 @@ output "log_export_map" {
   description = "Outputs from the log export module"
 
   value = {
-    filter                 = "${module.log_export.filter}"
-    log_sink_resource_id   = "${module.log_export.log_sink_resource_id}"
-    log_sink_resource_name = "${module.log_export.log_sink_resource_name}"
-    parent_resource_id     = "${module.log_export.parent_resource_id}"
-    writer_identity        = "${module.log_export.writer_identity}"
+    filter                 = module.log_export.filter
+    log_sink_resource_id   = module.log_export.log_sink_resource_id
+    log_sink_resource_name = module.log_export.log_sink_resource_name
+    parent_resource_id     = module.log_export.parent_resource_id
+    writer_identity        = module.log_export.writer_identity
   }
 }
 
@@ -30,12 +30,13 @@ output "destination_map" {
   description = "Outputs from the destination module"
 
   value = {
-    console_link        = "${module.destination.console_link}"
-    project             = "${module.destination.project}"
-    resource_name       = "${module.destination.resource_name}"
-    resource_id         = "${module.destination.resource_id}"
-    destination_uri     = "${module.destination.destination_uri}"
-    pubsub_subscriber   = "${module.destination.pubsub_subscriber}"
-    pubsub_subscription = "${module.destination.pubsub_subscription}"
+    console_link        = module.destination.console_link
+    project             = module.destination.project
+    resource_name       = module.destination.resource_name
+    resource_id         = module.destination.resource_id
+    destination_uri     = module.destination.destination_uri
+    pubsub_subscriber   = module.destination.pubsub_subscriber
+    pubsub_subscription = module.destination.pubsub_subscription
   }
 }
+

--- a/examples/pubsub/folder/variables.tf
+++ b/examples/pubsub/folder/variables.tf
@@ -21,3 +21,4 @@ variable "project_id" {
 variable "parent_resource_id" {
   description = "The ID of the project in which pubsub topic destination will be created."
 }
+

--- a/examples/pubsub/folder/versions.tf
+++ b/examples/pubsub/folder/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/pubsub/organization/main.tf
+++ b/examples/pubsub/organization/main.tf
@@ -26,18 +26,19 @@ resource "random_string" "suffix" {
 
 module "log_export" {
   source                 = "../../../"
-  destination_uri        = "${module.destination.destination_uri}"
+  destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "pubsub_org_${random_string.suffix.result}"
-  parent_resource_id     = "${var.parent_resource_id}"
+  parent_resource_id     = var.parent_resource_id
   parent_resource_type   = "organization"
   unique_writer_identity = "true"
 }
 
 module "destination" {
   source                   = "../../..//modules/pubsub"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   topic_name               = "pubsub-org-${random_string.suffix.result}"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
   create_subscriber        = "true"
 }
+

--- a/examples/pubsub/organization/outputs.tf
+++ b/examples/pubsub/organization/outputs.tf
@@ -18,11 +18,11 @@ output "log_export_map" {
   description = "Outputs from the log export module"
 
   value = {
-    filter                 = "${module.log_export.filter}"
-    log_sink_resource_id   = "${module.log_export.log_sink_resource_id}"
-    log_sink_resource_name = "${module.log_export.log_sink_resource_name}"
-    parent_resource_id     = "${module.log_export.parent_resource_id}"
-    writer_identity        = "${module.log_export.writer_identity}"
+    filter                 = module.log_export.filter
+    log_sink_resource_id   = module.log_export.log_sink_resource_id
+    log_sink_resource_name = module.log_export.log_sink_resource_name
+    parent_resource_id     = module.log_export.parent_resource_id
+    writer_identity        = module.log_export.writer_identity
   }
 }
 
@@ -30,12 +30,13 @@ output "destination_map" {
   description = "Outputs from the destination module"
 
   value = {
-    console_link        = "${module.destination.console_link}"
-    project             = "${module.destination.project}"
-    resource_name       = "${module.destination.resource_name}"
-    resource_id         = "${module.destination.resource_id}"
-    destination_uri     = "${module.destination.destination_uri}"
-    pubsub_subscriber   = "${module.destination.pubsub_subscriber}"
-    pubsub_subscription = "${module.destination.pubsub_subscription}"
+    console_link        = module.destination.console_link
+    project             = module.destination.project
+    resource_name       = module.destination.resource_name
+    resource_id         = module.destination.resource_id
+    destination_uri     = module.destination.destination_uri
+    pubsub_subscriber   = module.destination.pubsub_subscriber
+    pubsub_subscription = module.destination.pubsub_subscription
   }
 }
+

--- a/examples/pubsub/organization/variables.tf
+++ b/examples/pubsub/organization/variables.tf
@@ -21,3 +21,4 @@ variable "project_id" {
 variable "parent_resource_id" {
   description = "The ID of the project in which pubsub topic destination will be created."
 }
+

--- a/examples/pubsub/organization/versions.tf
+++ b/examples/pubsub/organization/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/pubsub/project/main.tf
+++ b/examples/pubsub/project/main.tf
@@ -26,18 +26,19 @@ resource "random_string" "suffix" {
 
 module "log_export" {
   source                 = "../../../"
-  destination_uri        = "${module.destination.destination_uri}"
+  destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "pubsub_project_${random_string.suffix.result}"
-  parent_resource_id     = "${var.parent_resource_id}"
+  parent_resource_id     = var.parent_resource_id
   parent_resource_type   = "project"
   unique_writer_identity = "true"
 }
 
 module "destination" {
   source                   = "../../..//modules/pubsub"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   topic_name               = "pubsub-project-${random_string.suffix.result}"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
   create_subscriber        = "true"
 }
+

--- a/examples/pubsub/project/outputs.tf
+++ b/examples/pubsub/project/outputs.tf
@@ -18,11 +18,11 @@ output "log_export_map" {
   description = "Outputs from the log export module"
 
   value = {
-    filter                 = "${module.log_export.filter}"
-    log_sink_resource_id   = "${module.log_export.log_sink_resource_id}"
-    log_sink_resource_name = "${module.log_export.log_sink_resource_name}"
-    parent_resource_id     = "${module.log_export.parent_resource_id}"
-    writer_identity        = "${module.log_export.writer_identity}"
+    filter                 = module.log_export.filter
+    log_sink_resource_id   = module.log_export.log_sink_resource_id
+    log_sink_resource_name = module.log_export.log_sink_resource_name
+    parent_resource_id     = module.log_export.parent_resource_id
+    writer_identity        = module.log_export.writer_identity
   }
 }
 
@@ -30,12 +30,13 @@ output "destination_map" {
   description = "Outputs from the destination module"
 
   value = {
-    console_link        = "${module.destination.console_link}"
-    project             = "${module.destination.project}"
-    resource_name       = "${module.destination.resource_name}"
-    resource_id         = "${module.destination.resource_id}"
-    destination_uri     = "${module.destination.destination_uri}"
-    pubsub_subscriber   = "${module.destination.pubsub_subscriber}"
-    pubsub_subscription = "${module.destination.pubsub_subscription}"
+    console_link        = module.destination.console_link
+    project             = module.destination.project
+    resource_name       = module.destination.resource_name
+    resource_id         = module.destination.resource_id
+    destination_uri     = module.destination.destination_uri
+    pubsub_subscriber   = module.destination.pubsub_subscriber
+    pubsub_subscription = module.destination.pubsub_subscription
   }
 }
+

--- a/examples/pubsub/project/variables.tf
+++ b/examples/pubsub/project/variables.tf
@@ -21,3 +21,4 @@ variable "project_id" {
 variable "parent_resource_id" {
   description = "The ID of the project in which pubsub topic destination will be created."
 }
+

--- a/examples/pubsub/project/versions.tf
+++ b/examples/pubsub/project/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/splunk-sink/main.tf
+++ b/examples/splunk-sink/main.tf
@@ -20,16 +20,17 @@ provider "google" {
 
 module "log_export" {
   source               = "terraform-google-modules/log-export/google"
-  destination_uri      = "${module.destination.destination_uri}"
+  destination_uri      = module.destination.destination_uri
   log_sink_name        = "test-splunk-sink"
-  parent_resource_id   = "${var.parent_resource_id}"
+  parent_resource_id   = var.parent_resource_id
   parent_resource_type = "project"
 }
 
 module "destination" {
   source                   = "terraform-google-modules/log-export/google//modules/pubsub"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   topic_name               = "splunk-sink"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
   create_subscriber        = "true"
 }
+

--- a/examples/splunk-sink/outputs.tf
+++ b/examples/splunk-sink/outputs.tf
@@ -16,20 +16,21 @@
 
 output "pubsub_topic_name" {
   description = "Pub/Sub topic name"
-  value       = "${module.destination.resource_id}"
+  value       = module.destination.resource_id
 }
 
 output "pubsub_topic_project" {
   description = "Pub/Sub topic project id"
-  value       = "${module.destination.project}"
+  value       = module.destination.project
 }
 
 output "pubsub_subscription_name" {
   description = "Pub/Sub topic subscription name"
-  value       = "${module.destination.pubsub_subscription}"
+  value       = module.destination.pubsub_subscription
 }
 
 output "pubsub_subscriber" {
   description = "Pub/Sub topic subscriber email"
-  value       = "${module.destination.pubsub_subscriber}"
+  value       = module.destination.pubsub_subscriber
 }
+

--- a/examples/splunk-sink/variables.tf
+++ b/examples/splunk-sink/variables.tf
@@ -21,3 +21,4 @@ variable "project_id" {
 variable "parent_resource_id" {
   description = "The ID of the project in which pubsub topic destination will be created."
 }
+

--- a/examples/splunk-sink/versions.tf
+++ b/examples/splunk-sink/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/storage/billing_account/main.tf
+++ b/examples/storage/billing_account/main.tf
@@ -20,16 +20,17 @@ provider "google" {
 
 module "log_export" {
   source                 = "../../../"
-  destination_uri        = "${module.destination.destination_uri}"
+  destination_uri        = module.destination.destination_uri
   log_sink_name          = "storage_example_logsink"
-  parent_resource_id     = "${var.parent_resource_id}"
+  parent_resource_id     = var.parent_resource_id
   parent_resource_type   = "billing_account"
   unique_writer_identity = "true"
 }
 
 module "destination" {
   source                   = "../../..//modules/storage"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   storage_bucket_name      = "storage_example_bucket"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
 }
+

--- a/examples/storage/billing_account/outputs.tf
+++ b/examples/storage/billing_account/outputs.tf
@@ -18,11 +18,11 @@ output "log_export_map" {
   description = "Outputs from the log export module"
 
   value = {
-    filter                 = "${module.log_export.filter}"
-    log_sink_resource_id   = "${module.log_export.log_sink_resource_id}"
-    log_sink_resource_name = "${module.log_export.log_sink_resource_name}"
-    parent_resource_id     = "${module.log_export.parent_resource_id}"
-    writer_identity        = "${module.log_export.writer_identity}"
+    filter                 = module.log_export.filter
+    log_sink_resource_id   = module.log_export.log_sink_resource_id
+    log_sink_resource_name = module.log_export.log_sink_resource_name
+    parent_resource_id     = module.log_export.parent_resource_id
+    writer_identity        = module.log_export.writer_identity
   }
 }
 
@@ -30,11 +30,12 @@ output "destination_map" {
   description = "Outputs from the destination module"
 
   value = {
-    console_link    = "${module.destination.console_link}"
-    project         = "${module.destination.project}"
-    resource_name   = "${module.destination.resource_name}"
-    resource_id     = "${module.destination.resource_id}"
-    self_link       = "${module.destination.self_link}"
-    destination_uri = "${module.destination.destination_uri}"
+    console_link    = module.destination.console_link
+    project         = module.destination.project
+    resource_name   = module.destination.resource_name
+    resource_id     = module.destination.resource_id
+    self_link       = module.destination.self_link
+    destination_uri = module.destination.destination_uri
   }
 }
+

--- a/examples/storage/billing_account/variables.tf
+++ b/examples/storage/billing_account/variables.tf
@@ -21,3 +21,4 @@ variable "project_id" {
 variable "parent_resource_id" {
   description = "The ID of the project in which storage bucket destination will be created."
 }
+

--- a/examples/storage/billing_account/versions.tf
+++ b/examples/storage/billing_account/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/storage/folder/main.tf
+++ b/examples/storage/folder/main.tf
@@ -26,17 +26,18 @@ resource "random_string" "suffix" {
 
 module "log_export" {
   source                 = "../../../"
-  destination_uri        = "${module.destination.destination_uri}"
+  destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "storage_folder_${random_string.suffix.result}"
-  parent_resource_id     = "${var.parent_resource_id}"
+  parent_resource_id     = var.parent_resource_id
   parent_resource_type   = "folder"
   unique_writer_identity = "true"
 }
 
 module "destination" {
   source                   = "../../..//modules/storage"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   storage_bucket_name      = "storage_folder_${random_string.suffix.result}"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
 }
+

--- a/examples/storage/folder/outputs.tf
+++ b/examples/storage/folder/outputs.tf
@@ -18,11 +18,11 @@ output "log_export_map" {
   description = "Outputs from the log export module"
 
   value = {
-    filter                 = "${module.log_export.filter}"
-    log_sink_resource_id   = "${module.log_export.log_sink_resource_id}"
-    log_sink_resource_name = "${module.log_export.log_sink_resource_name}"
-    parent_resource_id     = "${module.log_export.parent_resource_id}"
-    writer_identity        = "${module.log_export.writer_identity}"
+    filter                 = module.log_export.filter
+    log_sink_resource_id   = module.log_export.log_sink_resource_id
+    log_sink_resource_name = module.log_export.log_sink_resource_name
+    parent_resource_id     = module.log_export.parent_resource_id
+    writer_identity        = module.log_export.writer_identity
   }
 }
 
@@ -30,11 +30,12 @@ output "destination_map" {
   description = "Outputs from the destination module"
 
   value = {
-    console_link    = "${module.destination.console_link}"
-    project         = "${module.destination.project}"
-    resource_name   = "${module.destination.resource_name}"
-    resource_id     = "${module.destination.resource_id}"
-    self_link       = "${module.destination.self_link}"
-    destination_uri = "${module.destination.destination_uri}"
+    console_link    = module.destination.console_link
+    project         = module.destination.project
+    resource_name   = module.destination.resource_name
+    resource_id     = module.destination.resource_id
+    self_link       = module.destination.self_link
+    destination_uri = module.destination.destination_uri
   }
 }
+

--- a/examples/storage/folder/variables.tf
+++ b/examples/storage/folder/variables.tf
@@ -21,3 +21,4 @@ variable "project_id" {
 variable "parent_resource_id" {
   description = "The ID of the project in which storage bucket destination will be created."
 }
+

--- a/examples/storage/folder/versions.tf
+++ b/examples/storage/folder/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/storage/organization/main.tf
+++ b/examples/storage/organization/main.tf
@@ -26,17 +26,18 @@ resource "random_string" "suffix" {
 
 module "log_export" {
   source                 = "../../../"
-  destination_uri        = "${module.destination.destination_uri}"
+  destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "storage_org_${random_string.suffix.result}"
-  parent_resource_id     = "${var.parent_resource_id}"
+  parent_resource_id     = var.parent_resource_id
   parent_resource_type   = "organization"
   unique_writer_identity = "true"
 }
 
 module "destination" {
   source                   = "../../..//modules/storage"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   storage_bucket_name      = "storage_org_${random_string.suffix.result}"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
 }
+

--- a/examples/storage/organization/outputs.tf
+++ b/examples/storage/organization/outputs.tf
@@ -18,11 +18,11 @@ output "log_export_map" {
   description = "Outputs from the log export module"
 
   value = {
-    filter                 = "${module.log_export.filter}"
-    log_sink_resource_id   = "${module.log_export.log_sink_resource_id}"
-    log_sink_resource_name = "${module.log_export.log_sink_resource_name}"
-    parent_resource_id     = "${module.log_export.parent_resource_id}"
-    writer_identity        = "${module.log_export.writer_identity}"
+    filter                 = module.log_export.filter
+    log_sink_resource_id   = module.log_export.log_sink_resource_id
+    log_sink_resource_name = module.log_export.log_sink_resource_name
+    parent_resource_id     = module.log_export.parent_resource_id
+    writer_identity        = module.log_export.writer_identity
   }
 }
 
@@ -30,11 +30,12 @@ output "destination_map" {
   description = "Outputs from the destination module"
 
   value = {
-    console_link    = "${module.destination.console_link}"
-    project         = "${module.destination.project}"
-    resource_name   = "${module.destination.resource_name}"
-    resource_id     = "${module.destination.resource_id}"
-    self_link       = "${module.destination.self_link}"
-    destination_uri = "${module.destination.destination_uri}"
+    console_link    = module.destination.console_link
+    project         = module.destination.project
+    resource_name   = module.destination.resource_name
+    resource_id     = module.destination.resource_id
+    self_link       = module.destination.self_link
+    destination_uri = module.destination.destination_uri
   }
 }
+

--- a/examples/storage/organization/variables.tf
+++ b/examples/storage/organization/variables.tf
@@ -21,3 +21,4 @@ variable "project_id" {
 variable "parent_resource_id" {
   description = "The ID of the project in which storage bucket destination will be created."
 }
+

--- a/examples/storage/organization/versions.tf
+++ b/examples/storage/organization/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/storage/project/main.tf
+++ b/examples/storage/project/main.tf
@@ -26,17 +26,18 @@ resource "random_string" "suffix" {
 
 module "log_export" {
   source                 = "../../../"
-  destination_uri        = "${module.destination.destination_uri}"
+  destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "storage_project_${random_string.suffix.result}"
-  parent_resource_id     = "${var.parent_resource_id}"
+  parent_resource_id     = var.parent_resource_id
   parent_resource_type   = "project"
   unique_writer_identity = "true"
 }
 
 module "destination" {
   source                   = "../../..//modules/storage"
-  project_id               = "${var.project_id}"
+  project_id               = var.project_id
   storage_bucket_name      = "storage_project_${random_string.suffix.result}"
-  log_sink_writer_identity = "${module.log_export.writer_identity}"
+  log_sink_writer_identity = module.log_export.writer_identity
 }
+

--- a/examples/storage/project/outputs.tf
+++ b/examples/storage/project/outputs.tf
@@ -18,11 +18,11 @@ output "log_export_map" {
   description = "Outputs from the log export module"
 
   value = {
-    filter                 = "${module.log_export.filter}"
-    log_sink_resource_id   = "${module.log_export.log_sink_resource_id}"
-    log_sink_resource_name = "${module.log_export.log_sink_resource_name}"
-    parent_resource_id     = "${module.log_export.parent_resource_id}"
-    writer_identity        = "${module.log_export.writer_identity}"
+    filter                 = module.log_export.filter
+    log_sink_resource_id   = module.log_export.log_sink_resource_id
+    log_sink_resource_name = module.log_export.log_sink_resource_name
+    parent_resource_id     = module.log_export.parent_resource_id
+    writer_identity        = module.log_export.writer_identity
   }
 }
 
@@ -30,11 +30,12 @@ output "destination_map" {
   description = "Outputs from the destination module"
 
   value = {
-    console_link    = "${module.destination.console_link}"
-    project         = "${module.destination.project}"
-    resource_name   = "${module.destination.resource_name}"
-    resource_id     = "${module.destination.resource_id}"
-    self_link       = "${module.destination.self_link}"
-    destination_uri = "${module.destination.destination_uri}"
+    console_link    = module.destination.console_link
+    project         = module.destination.project
+    resource_name   = module.destination.resource_name
+    resource_id     = module.destination.resource_id
+    self_link       = module.destination.self_link
+    destination_uri = module.destination.destination_uri
   }
 }
+

--- a/examples/storage/project/variables.tf
+++ b/examples/storage/project/variables.tf
@@ -21,3 +21,4 @@ variable "project_id" {
 variable "parent_resource_id" {
   description = "The ID of the project in which storage bucket destination will be created."
 }
+

--- a/examples/storage/project/versions.tf
+++ b/examples/storage/project/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This commit is the result of performing a `terraform 0.12upgrade .` on
every example directory, which allows Terraform to automatically update
syntax for version 0.12. I've tested the changes by running `make
test_integration_docker` and everything comes back okay.