### PR TITLE
Combine parent_resource_id and parent_resource_type into a single param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2019-XX-YY
+
+### Changed
+
+- Changed the interface. Combined variable parent now incorporates `parent_resource_type` and `parent_resource_id` [#30]:
+```hcl
+variable "parent" {
+  description = "The GCP parent attributes: `resource_type` - must be one of the following: 'project', 'folder', 'billing_account', or 'organization'; `resource_id` - the ID of the GCP resource in which you create the log sink. If var.parent_resource_type is set to 'project', then this is the Project ID (and etc)."
+  type        = object({ resource_type = string, resource_id = string })
+}
+```
+
 ## [3.0.0] - 2019-07-23
 
 ### Changed
@@ -45,13 +57,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release of log export module.
 
-[Unreleased]: https://github.com/terraform-google-modules/terraform-google-log-export/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/terraform-google-modules/terraform-google-log-export/compare/v3.0.1...HEAD
+[3.0.1]: https://github.com/terraform-google-modules/terraform-google-log-export/compare/v2.3.0...v3.0.1
 [3.0.0]: https://github.com/terraform-google-modules/terraform-google-log-export/compare/v2.3.0...v3.0.0
 [2.3.0]: https://github.com/terraform-google-modules/terraform-google-log-export/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/terraform-google-modules/terraform-google-log-export/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/terraform-google-modules/terraform-google-log-export/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/terraform-google-modules/terraform-google-log-export/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/terraform-google-modules/terraform-google-log-export/releases/tag/v1.0.0
+[#30]: https://github.com/terraform-google-modules/terraform-google-log-export/pull/30
 [#22]: https://github.com/terraform-google-modules/terraform-google-log-export/pull/22
 [#19]: https://github.com/terraform-google-modules/terraform-google-log-export/pull/19
 [#18]: https://github.com/terraform-google-modules/terraform-google-log-export/pull/18

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ module "log_export" {
   destination_uri        = "${module.destination.destination_uri}"
   filter                 = "severity >= ERROR"
   log_sink_name          = "storage_example_logsink"
-  parent_resource_id     = "sample-project"
-  parent_resource_type   = "project"
+  parent                 = {
+    resource_type: "project",
+    resource_id: "sample-project"
+  }
   unique_writer_identity = "true"
 }
 
@@ -51,8 +53,7 @@ so that all dependencies are met.
 | filter | The filter to apply when exporting logs. Only log entries that match the filter are exported. Default is '' which exports all logs. | string | `""` | no |
 | include\_children | Only valid if 'organization' or 'folder' is chosen as var.parent_resource.type. Determines whether or not to include children organizations/folders in the sink export. If true, logs associated with child projects are also exported; otherwise only logs relating to the provided organization/folder are included. | string | `"false"` | no |
 | log\_sink\_name | The name of the log sink to be created. | string | n/a | yes |
-| parent\_resource\_id | The ID of the GCP resource in which you create the log sink. If var.parent_resource_type is set to 'project', then this is the Project ID (and etc). | string | n/a | yes |
-| parent\_resource\_type | The GCP resource in which you create the log sink. The value must not be computed, and must be one of the following: 'project', 'folder', 'billing_account', or 'organization'. | string | `"project"` | no |
+| parent | The GCP parent attributes: `resource_type` - must be one of the following: 'project', 'folder', 'billing_account', or 'organization'; `resource_id` - the ID of the GCP resource in which you create the log sink. If var.parent_resource_type is set to 'project', then this is the Project ID (and etc). | object | n/a | yes |
 | unique\_writer\_identity | Whether or not to create a unique identity associated with this sink. If false (the default), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for the logging sink. | string | `"false"` | no |
 
 ## Outputs

--- a/examples/bigquery/billing_account/main.tf
+++ b/examples/bigquery/billing_account/main.tf
@@ -22,8 +22,10 @@ module "log_export" {
   source                 = "../../../"
   destination_uri        = module.destination.destination_uri
   log_sink_name          = "bigquery_example_logsink"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "billing_account"
+  parent                 = {
+    resource_type: "billing_account",
+    resource_id: var.parent_resource_id
+  }
   unique_writer_identity = "true"
 }
 

--- a/examples/bigquery/folder/main.tf
+++ b/examples/bigquery/folder/main.tf
@@ -29,8 +29,10 @@ module "log_export" {
   destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "bigquery_folder_${random_string.suffix.result}"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "folder"
+  parent                 = {
+    resource_type: "folder",
+    resource_id: var.parent_resource_id
+  }
   unique_writer_identity = "true"
 }
 

--- a/examples/bigquery/organization/main.tf
+++ b/examples/bigquery/organization/main.tf
@@ -29,8 +29,10 @@ module "log_export" {
   destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "bigquery_org_${random_string.suffix.result}"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "organization"
+  parent                 = {
+    resource_type: "organization",
+    resource_id: var.parent_resource_id
+  }
   unique_writer_identity = "true"
 }
 
@@ -40,4 +42,3 @@ module "destination" {
   dataset_name             = "bq_org_${random_string.suffix.result}"
   log_sink_writer_identity = module.log_export.writer_identity
 }
-

--- a/examples/bigquery/project/main.tf
+++ b/examples/bigquery/project/main.tf
@@ -29,8 +29,10 @@ module "log_export" {
   destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "bigquery_project_${random_string.suffix.result}"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "project"
+  parent                 = {
+    resource_type: "project",
+    resource_id: var.parent_resource_id
+  }
   unique_writer_identity = "true"
 }
 
@@ -40,4 +42,3 @@ module "destination" {
   dataset_name             = "bq_project_${random_string.suffix.result}"
   log_sink_writer_identity = module.log_export.writer_identity
 }
-

--- a/examples/pubsub/billing_account/main.tf
+++ b/examples/pubsub/billing_account/main.tf
@@ -22,8 +22,10 @@ module "log_export" {
   source                 = "../../../"
   destination_uri        = module.destination.destination_uri
   log_sink_name          = "pubsub_example_logsink"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "billing_account"
+  parent                 = {
+    resource_type: "billing_account",
+    resource_id: var.parent_resource_id
+  }
   unique_writer_identity = "true"
 }
 
@@ -34,4 +36,3 @@ module "destination" {
   log_sink_writer_identity = module.log_export.writer_identity
   create_subscriber        = "true"
 }
-

--- a/examples/pubsub/folder/main.tf
+++ b/examples/pubsub/folder/main.tf
@@ -29,8 +29,10 @@ module "log_export" {
   destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "pubsub_folder_${random_string.suffix.result}"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "folder"
+  parent                 = {
+    resource_type: "folder",
+    resource_id: var.parent_resource_id
+  }
   unique_writer_identity = "true"
 }
 
@@ -41,4 +43,3 @@ module "destination" {
   log_sink_writer_identity = module.log_export.writer_identity
   create_subscriber        = "true"
 }
-

--- a/examples/pubsub/organization/main.tf
+++ b/examples/pubsub/organization/main.tf
@@ -29,8 +29,10 @@ module "log_export" {
   destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "pubsub_org_${random_string.suffix.result}"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "organization"
+  parent                 = {
+    resource_type: "organization",
+    resource_id: var.parent_resource_id
+  }
   unique_writer_identity = "true"
 }
 
@@ -41,4 +43,3 @@ module "destination" {
   log_sink_writer_identity = module.log_export.writer_identity
   create_subscriber        = "true"
 }
-

--- a/examples/pubsub/project/main.tf
+++ b/examples/pubsub/project/main.tf
@@ -29,8 +29,10 @@ module "log_export" {
   destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "pubsub_project_${random_string.suffix.result}"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "project"
+  parent                 = {
+    resource_type: "project",
+    resource_id: var.parent_resource_id
+  }
   unique_writer_identity = "true"
 }
 
@@ -41,4 +43,3 @@ module "destination" {
   log_sink_writer_identity = module.log_export.writer_identity
   create_subscriber        = "true"
 }
-

--- a/examples/splunk-sink/main.tf
+++ b/examples/splunk-sink/main.tf
@@ -19,11 +19,13 @@ provider "google" {
 }
 
 module "log_export" {
-  source               = "terraform-google-modules/log-export/google"
-  destination_uri      = module.destination.destination_uri
-  log_sink_name        = "test-splunk-sink"
-  parent_resource_id   = var.parent_resource_id
-  parent_resource_type = "project"
+  source          = "../../"
+  destination_uri = module.destination.destination_uri
+  log_sink_name   = "test-splunk-sink"
+  parent          = {
+    resource_type: "project",
+    resource_id: var.parent_resource_id
+  }
 }
 
 module "destination" {
@@ -33,4 +35,3 @@ module "destination" {
   log_sink_writer_identity = module.log_export.writer_identity
   create_subscriber        = "true"
 }
-

--- a/examples/storage/billing_account/main.tf
+++ b/examples/storage/billing_account/main.tf
@@ -22,8 +22,10 @@ module "log_export" {
   source                 = "../../../"
   destination_uri        = module.destination.destination_uri
   log_sink_name          = "storage_example_logsink"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "billing_account"
+  parent                 = {
+    resource_type: "billing_account",
+    resource_id: var.parent_resource_id
+  }
   unique_writer_identity = "true"
 }
 

--- a/examples/storage/folder/main.tf
+++ b/examples/storage/folder/main.tf
@@ -29,8 +29,10 @@ module "log_export" {
   destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "storage_folder_${random_string.suffix.result}"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "folder"
+  parent                 = {
+    resource_type: "folder",
+    resource_id: var.parent_resource_id
+  }
   unique_writer_identity = "true"
 }
 

--- a/examples/storage/organization/main.tf
+++ b/examples/storage/organization/main.tf
@@ -29,8 +29,10 @@ module "log_export" {
   destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "storage_org_${random_string.suffix.result}"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "organization"
+  parent                 = {
+    resource_type: "organization",
+    resource_id: var.parent_resource_id
+  }
   unique_writer_identity = "true"
 }
 
@@ -40,4 +42,3 @@ module "destination" {
   storage_bucket_name      = "storage_org_${random_string.suffix.result}"
   log_sink_writer_identity = module.log_export.writer_identity
 }
-

--- a/examples/storage/project/main.tf
+++ b/examples/storage/project/main.tf
@@ -29,8 +29,10 @@ module "log_export" {
   destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
   log_sink_name          = "storage_project_${random_string.suffix.result}"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "project"
+  parent                 = {
+    resource_type: "project",
+    resource_id: var.parent_resource_id
+  }
   unique_writer_identity = "true"
 }
 
@@ -40,4 +42,3 @@ module "destination" {
   storage_bucket_name      = "storage_project_${random_string.suffix.result}"
   log_sink_writer_identity = module.log_export.writer_identity
 }
-

--- a/main.tf
+++ b/main.tf
@@ -18,16 +18,16 @@
 # Local variables #
 #-----------------#
 locals {
-  is_project_level = var.parent_resource_type == "project"
-  is_folder_level  = var.parent_resource_type == "folder"
-  is_org_level     = var.parent_resource_type == "organization"
-  is_billing_level = var.parent_resource_type == "billing_account"
+  is_project_level = var.parent.resource_type == "project"
+  is_folder_level  = var.parent.resource_type == "folder"
+  is_org_level     = var.parent.resource_type == "organization"
+  is_billing_level = var.parent.resource_type == "billing_account"
 
   # Locals for outputs to ensure the value is available after the resource is created
-  log_sink_writer_identity = local.is_project_level ? element(concat(google_logging_project_sink.sink.*.writer_identity, list("")), 0) : local.is_folder_level ? element(concat(google_logging_folder_sink.sink.*.writer_identity, list("")), 0) : local.is_org_level ? element(concat(google_logging_organization_sink.sink.*.writer_identity, list("")), 0) : local.is_billing_level ? element(concat(google_logging_billing_account_sink.sink.*.writer_identity, list("")), 0) : ""
-  log_sink_resource_id     = local.is_project_level ? element(concat(google_logging_project_sink.sink.*.id, list("")), 0) : local.is_folder_level ? element(concat(google_logging_folder_sink.sink.*.id, list("")), 0) : local.is_org_level ? element(concat(google_logging_organization_sink.sink.*.id, list("")), 0) : local.is_billing_level ? element(concat(google_logging_billing_account_sink.sink.*.id, list("")), 0) : ""
-  log_sink_resource_name   = local.is_project_level ? element(concat(google_logging_project_sink.sink.*.name, list("")), 0) : local.is_folder_level ? element(concat(google_logging_folder_sink.sink.*.name, list("")), 0) : local.is_org_level ? element(concat(google_logging_organization_sink.sink.*.name, list("")), 0) : local.is_billing_level ? element(concat(google_logging_billing_account_sink.sink.*.name, list("")), 0) : ""
-  log_sink_parent_id       = local.is_project_level ? element(concat(google_logging_project_sink.sink.*.project, list("")), 0) : local.is_folder_level ? element(concat(google_logging_folder_sink.sink.*.folder, list("")), 0) : local.is_org_level ? element(concat(google_logging_organization_sink.sink.*.org_id, list("")), 0) : local.is_billing_level ? element(concat(google_logging_billing_account_sink.sink.*.billing_account, list("")), 0) : ""
+  log_sink_writer_identity = local.is_project_level ? concat(google_logging_project_sink.sink.*.writer_identity, list(""))[0] : local.is_folder_level ? concat(google_logging_folder_sink.sink.*.writer_identity, list(""))[0] : local.is_org_level ? concat(google_logging_organization_sink.sink.*.writer_identity, list(""))[0] : local.is_billing_level ? concat(google_logging_billing_account_sink.sink.*.writer_identity, list(""))[0] : ""
+  log_sink_resource_id     = local.is_project_level ? concat(google_logging_project_sink.sink.*.id, list(""))[0] : local.is_folder_level ? concat(google_logging_folder_sink.sink.*.id, list(""))[0] : local.is_org_level ? concat(google_logging_organization_sink.sink.*.id, list(""))[0] : local.is_billing_level ? concat(google_logging_billing_account_sink.sink.*.id, list(""))[0] : ""
+  log_sink_resource_name   = local.is_project_level ? concat(google_logging_project_sink.sink.*.name, list(""))[0] : local.is_folder_level ? concat(google_logging_folder_sink.sink.*.name, list(""))[0] : local.is_org_level ? concat(google_logging_organization_sink.sink.*.name, list(""))[0] : local.is_billing_level ? concat(google_logging_billing_account_sink.sink.*.name, list(""))[0] : ""
+  log_sink_parent_id       = local.is_project_level ? concat(google_logging_project_sink.sink.*.project, list(""))[0] : local.is_folder_level ? concat(google_logging_folder_sink.sink.*.folder, list(""))[0] : local.is_org_level ? concat(google_logging_organization_sink.sink.*.org_id, list(""))[0] : local.is_billing_level ? concat(google_logging_billing_account_sink.sink.*.billing_account, list(""))[0] : ""
 }
 
 
@@ -38,7 +38,7 @@ locals {
 resource "google_logging_project_sink" "sink" {
   count                  = local.is_project_level ? 1 : 0
   name                   = var.log_sink_name
-  project                = var.parent_resource_id
+  project                = var.parent.resource_id
   filter                 = var.filter
   destination            = var.destination_uri
   unique_writer_identity = var.unique_writer_identity
@@ -48,7 +48,7 @@ resource "google_logging_project_sink" "sink" {
 resource "google_logging_folder_sink" "sink" {
   count            = local.is_folder_level ? 1 : 0
   name             = var.log_sink_name
-  folder           = var.parent_resource_id
+  folder           = var.parent.resource_id
   filter           = var.filter
   include_children = var.include_children
   destination      = var.destination_uri
@@ -58,7 +58,7 @@ resource "google_logging_folder_sink" "sink" {
 resource "google_logging_organization_sink" "sink" {
   count            = local.is_org_level ? 1 : 0
   name             = var.log_sink_name
-  org_id           = var.parent_resource_id
+  org_id           = var.parent.resource_id
   filter           = var.filter
   include_children = var.include_children
   destination      = var.destination_uri
@@ -68,7 +68,7 @@ resource "google_logging_organization_sink" "sink" {
 resource "google_logging_billing_account_sink" "sink" {
   count           = local.is_billing_level ? 1 : 0
   name            = var.log_sink_name
-  billing_account = var.parent_resource_id
+  billing_account = var.parent.resource_id
   filter          = var.filter
   destination     = var.destination_uri
 }

--- a/modules/bigquery/main.tf
+++ b/modules/bigquery/main.tf
@@ -19,10 +19,7 @@
 #-----------------#
 
 locals {
-  dataset_name = element(
-    concat(google_bigquery_dataset.dataset.*.dataset_id, [""]),
-    0,
-  )
+  dataset_name = concat(google_bigquery_dataset.dataset.*.dataset_id, [""])[0]
   destination_uri = "bigquery.googleapis.com/projects/${var.project_id}/datasets/${local.dataset_name}"
 }
 

--- a/modules/pubsub/README.md
+++ b/modules/pubsub/README.md
@@ -40,7 +40,7 @@ so that all dependencies are met.
 | create\_subscriber | Whether to create a subscription to the topic that was created and used for log entries matching the filter. If 'true', a subscription is created along with a service account that is granted roles/pubsub.subscriber and roles/pubsub.viewer to the topic. | string | `"false"` | no |
 | log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | string | n/a | yes |
 | project\_id | The ID of the project in which the pubsub topic will be created. | string | n/a | yes |
-| topic\_labels | A set of key/value label pairs to assign to the pubsub topic. | map | `<map>` | no |
+| topic\_labels | A set of key/value label pairs to assign to the pubsub topic. | map(string) | `<map>` | no |
 | topic\_name | The name of the pubsub topic to be created and used for log entries matching the filter. | string | n/a | yes |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -32,17 +32,12 @@ variable "log_sink_name" {
   description = "The name of the log sink to be created."
 }
 
-variable "parent_resource_id" {
-  description = "The ID of the GCP resource in which you create the log sink. If var.parent_resource_type is set to 'project', then this is the Project ID (and etc)."
-}
-
-variable "parent_resource_type" {
-  description = "The GCP resource in which you create the log sink. The value must not be computed, and must be one of the following: 'project', 'folder', 'billing_account', or 'organization'."
-  default     = "project"
-}
-
 variable "unique_writer_identity" {
   description = "Whether or not to create a unique identity associated with this sink. If false (the default), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for the logging sink."
   default     = "false"
 }
 
+variable "parent" {
+  description = "The GCP parent attributes: `resource_type` - must be one of the following: 'project', 'folder', 'billing_account', or 'organization'; `resource_id` - the ID of the GCP resource in which you create the log sink. If var.parent_resource_type is set to 'project', then this is the Project ID (and etc)."
+  type        = object({ resource_type = string, resource_id = string })
+}


### PR DESCRIPTION
Fixes #28 

Changed interface by replacing with a new `parent` variable which incorporate the old `parent_resource_type` and `parent_resource_id`.

```hcl
variable "parent" {
  description = "The GCP parent attributes: `resource_type` - must be one of the following: 'project', 'folder', 'billing_account', or 'organization'; `resource_id` - the ID of the GCP resource in which you create the log sink. If var.parent_resource_type is set to 'project', then this is the Project ID (and etc)."
  type        = object({ resource_type = string, resource_id = string })
}
```
Please note: this version is different to [newer PR](https://github.com/terraform-google-modules/terraform-google-log-export/pull/32) which implements the same in a string variable(that way may be less optimal as it requires extra parsing/extra function calls)

Not related: removed not required element call in `modules/bigquery/main.tf` (to be addressed across
code base)