### PR TITLE
Upgrade to google-provider 3.5.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Migrated to Google Provider version 3.5.x [#45]
 
 ## [3.2.0] - 2019-12-12
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,34 @@ submodules, and example modules are all functionally correct.
 ### Test Environment
 The easiest way to test the module is in an isolated test project. The setup for such a project is defined in [test/setup](./test/setup/) directory.
 
-To use this setup, you need a service account with Project Creator access on a folder. Export the Service Account credentials to your environment like so:
+To use this setup, you need:
+
+- A service account, with the following permissions:
+  * Project Creator access on a defined folder
+  * Billing account Admin on a billing account
+  * Logging Admin on the organisation
+  * Logging Admin on a defined folder
+  * Organisation Admin on the organisation
+  These permissions seem quite broad, but are needed to be able to test the organisational logging sink exports.
+- The project where this service-account resides needs to have the following APIs enabled:
+  * bigquery.googleapis.com
+  * bigquerystorage.googleapis.com
+  * cloudapis.googleapis.com
+  * cloudbilling.googleapis.com
+  * cloudresourcemanager.googleapis.com
+  * iam.googleapis.com
+  * iamcredentials.googleapis.com
+  * servicemanagement.googleapis.com
+  * serviceusage.googleapis.com
+  * storage-api.googleapis.com
+  * storage-component.googleapis.com
+- No organisational policies in place that prevent things, such as:
+  * No location restrictions
+  * No enforcement of bucket policy only
+  * No disabling of the creation of the default network.
+  For these policies it is ok if you 'undo' them at the defined folder.
+
+Export the Service Account credentials to your environment like so:
 
 ```
 export SERVICE_ACCOUNT_JSON=$(< credentials.json)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ so that all dependencies are met.
 ## Requirements
 ### Terraform plugins
 - [Terraform](https://www.terraform.io/downloads.html) 0.12.x
-- [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) plugin ~> v2.7.x
+- [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) plugin ~> v3.5.x
 
 ### Configure a Service Account
 In order to execute this module you must have a Service Account with the following:
@@ -106,7 +106,7 @@ In order to operate with the Service Account you must activate the following API
 - Service Usage API - serviceusage.googleapis.com
 - Stackdriver Logging API - logging.googleapis.com
 - Cloud Storage JSON API - storage-api.googleapis.com
-- BigQuery API - bigquery-json.googleapis.com
+- BigQuery API - bigquery.googleapis.com
 - Cloud Pub/Sub API - pubsub.googleapis.com
 
 ## Install

--- a/examples/bigquery/billing_account/versions.tf
+++ b/examples/bigquery/billing_account/versions.tf
@@ -19,5 +19,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/examples/bigquery/folder/versions.tf
+++ b/examples/bigquery/folder/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/examples/bigquery/organization/versions.tf
+++ b/examples/bigquery/organization/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/examples/bigquery/project/versions.tf
+++ b/examples/bigquery/project/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/examples/datadog-sink/main.tf
+++ b/examples/datadog-sink/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.0"
+  version = "~> 3.5"
 }
 
 locals {

--- a/examples/pubsub/billing_account/versions.tf
+++ b/examples/pubsub/billing_account/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/examples/pubsub/folder/versions.tf
+++ b/examples/pubsub/folder/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/examples/pubsub/organization/versions.tf
+++ b/examples/pubsub/organization/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/examples/pubsub/project/versions.tf
+++ b/examples/pubsub/project/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/examples/splunk-sink/main.tf
+++ b/examples/splunk-sink/main.tf
@@ -16,7 +16,7 @@
 
 
 module "log_export" {
-  source               = "terraform-google-modules/log-export/google"
+  source               = "../.."
   destination_uri      = module.destination.destination_uri
   log_sink_name        = "test-splunk-sink"
   parent_resource_id   = var.parent_resource_id
@@ -24,10 +24,9 @@ module "log_export" {
 }
 
 module "destination" {
-  source                   = "terraform-google-modules/log-export/google//modules/pubsub"
+  source                   = "../..//modules/pubsub"
   project_id               = var.project_id
   topic_name               = "splunk-sink"
   log_sink_writer_identity = module.log_export.writer_identity
   create_subscriber        = true
 }
-

--- a/examples/splunk-sink/versions.tf
+++ b/examples/splunk-sink/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/examples/storage/billing_account/versions.tf
+++ b/examples/storage/billing_account/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/examples/storage/folder/versions.tf
+++ b/examples/storage/folder/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/examples/storage/organization/versions.tf
+++ b/examples/storage/organization/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/examples/storage/project/versions.tf
+++ b/examples/storage/project/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/modules/bigquery/main.tf
+++ b/modules/bigquery/main.tf
@@ -31,7 +31,7 @@ locals {
 #----------------#
 resource "google_project_service" "enable_destination_api" {
   project            = var.project_id
-  service            = "bigquery-json.googleapis.com"
+  service            = "bigquery.googleapis.com"
   disable_on_destroy = false
 }
 

--- a/modules/bigquery/versions.tf
+++ b/modules/bigquery/versions.tf
@@ -18,6 +18,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = "~> 2.12"
+    google = "~> 3.5"
   }
 }

--- a/modules/pubsub/versions.tf
+++ b/modules/pubsub/versions.tf
@@ -18,6 +18,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = "~> 2.12"
+    google = "~> 3.5"
   }
 }

--- a/modules/storage/versions.tf
+++ b/modules/storage/versions.tf
@@ -18,6 +18,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = "~> 2.12"
+    google = "~> 3.5"
   }
 }

--- a/test/fixtures/computed_values/main.tf
+++ b/test/fixtures/computed_values/main.tf
@@ -29,7 +29,6 @@ resource "google_project" "computed" {
 
 module "log_export" {
   source             = "../../../examples/storage/project"
-  parent_resource_id = google_project.computed.id
-  project_id         = google_project.computed.id
+  parent_resource_id = google_project.computed.project_id
+  project_id         = google_project.computed.project_id
 }
-

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,7 +16,7 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 5.0"
+  version = "~> 7.0"
 
   name              = "ci-log-export"
   random_project_id = true
@@ -29,7 +29,7 @@ module "project" {
     "oslogin.googleapis.com",
     "serviceusage.googleapis.com",
     "compute.googleapis.com",
-    "bigquery-json.googleapis.com",
+    "bigquery.googleapis.com",
     "pubsub.googleapis.com",
     "storage-component.googleapis.com",
     "storage-api.googleapis.com",
@@ -47,3 +47,4 @@ resource "null_resource" "wait_apis" {
   }
   depends_on = [module.project.project_id]
 }
+

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }
 
 provider "google-beta" {
-  version = "~> 2.12.0"
+  version = "~> 3.5.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -16,7 +16,8 @@
 
 terraform {
   required_version = ">= 0.12"
+
   required_providers {
-    google = "~> 2.12"
+    google = "~> 3.5"
   }
 }


### PR DESCRIPTION
Fixes #45 

Work done:
- upgraded all version-files to google-provider 3.5.x
- upgraded the project factory to version 7.0
- switched to bigquery.googleapis.com, since bigquery-json doesn't work on new projects anymore
- fixed 1 id-usage where project-id should be used
- updated test setup documentation to fix the issues I ran into when setting up my test environment