### PR TITLE
Adding the option to define 'bucket_policy_only' value on buckets

### DIFF
--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -36,6 +36,7 @@ so that all dependencies are met.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| bucket\_policy\_only | Enables Bucket Policy Only access to a bucket. | bool | `"false"` | no |
 | location | The location of the storage bucket. | string | `"US"` | no |
 | log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | string | n/a | yes |
 | project\_id | The ID of the project in which the storage bucket will be created. | string | n/a | yes |

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -32,11 +32,12 @@ resource "google_project_service" "enable_destination_api" {
 # Storage bucket #
 #----------------#
 resource "google_storage_bucket" "bucket" {
-  name          = var.storage_bucket_name
-  project       = google_project_service.enable_destination_api.project
-  storage_class = var.storage_class
-  location      = var.location
-  force_destroy = true
+  name               = var.storage_bucket_name
+  project            = google_project_service.enable_destination_api.project
+  storage_class      = var.storage_class
+  location           = var.location
+  force_destroy      = true
+  bucket_policy_only = var.bucket_policy_only
 }
 
 #--------------------------------#

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -41,3 +41,8 @@ variable "storage_class" {
   default     = "MULTI_REGIONAL"
 }
 
+variable "bucket_policy_only" {
+  description = "Enables Bucket Policy Only access to a bucket."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This way, if not defined it continues to use "false" (as it is the module's input default value), but expands and allows users to define their own values if needed