### PR TITLE
[WIP] Migrate bigquery and storage destination to modules

### DIFF
--- a/modules/bigquery/outputs.tf
+++ b/modules/bigquery/outputs.tf
@@ -16,31 +16,30 @@
 
 output "console_link" {
   description = "The console link to the destination bigquery dataset"
-  value       = "https://bigquery.cloud.google.com/dataset/${var.project_id}:${local.dataset_name}"
+  value       = "https://bigquery.cloud.google.com/dataset/${var.project_id}:${module.dataset.bigquery_dataset.dataset_id}"
 }
 
 output "project" {
   description = "The project in which the bigquery dataset was created."
-  value       = google_bigquery_dataset.dataset.project
+  value       = module.dataset.project
 }
 
 output "resource_name" {
   description = "The resource name for the destination bigquery dataset"
-  value       = local.dataset_name
+  value       = module.dataset.bigquery_dataset.dataset_id
 }
 
 output "resource_id" {
   description = "The resource id for the destination bigquery dataset"
-  value       = google_bigquery_dataset.dataset.id
+  value       = module.dataset.bigquery_dataset.id
 }
 
 output "self_link" {
   description = "The self_link URI for the destination bigquery dataset"
-  value       = google_bigquery_dataset.dataset.self_link
+  value       = module.dataset.bigquery_dataset.self_link
 }
 
 output "destination_uri" {
   description = "The destination URI for the bigquery dataset."
   value       = local.destination_uri
 }
-

--- a/modules/bigquery/variables.tf
+++ b/modules/bigquery/variables.tf
@@ -30,9 +30,15 @@ variable "project_id" {
 }
 
 variable "location" {
-  description = "The location of the storage bucket."
+  description = "The location of the bigquery dataset."
   type        = string
   default     = "US"
+}
+
+variable "access" {
+  description = "The access for the bigquery dataset."
+  type        = any
+  default     = null
 }
 
 variable "delete_contents_on_destroy" {

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -16,31 +16,30 @@
 
 output "console_link" {
   description = "The console link to the destination storage bucket"
-  value       = "https://console.cloud.google.com/storage/browser/${local.storage_bucket_name}?project=${var.project_id}"
+  value       = "https://console.cloud.google.com/storage/browser/${module.bucket.bucket.name}?project=${var.project_id}"
 }
 
 output "project" {
   description = "The project in which the storage bucket was created."
-  value       = google_storage_bucket.bucket.project
+  value       = module.bucket.bucket.project
 }
 
 output "resource_name" {
   description = "The resource name for the destination storage bucket"
-  value       = local.storage_bucket_name
+  value       = module.bucket.bucket.name
 }
 
 output "resource_id" {
   description = "The resource id for the destination storage bucket"
-  value       = google_storage_bucket.bucket.id
+  value       = module.bucket.bucket.id
 }
 
 output "self_link" {
   description = "The self_link URI for the destination storage bucket"
-  value       = google_storage_bucket.bucket.self_link
+  value       = module.bucket.bucket.self_link
 }
 
 output "destination_uri" {
   description = "The destination URI for the storage bucket."
   value       = local.destination_uri
 }
-

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -38,11 +38,17 @@ variable "location" {
 variable "storage_class" {
   description = "The storage class of the storage bucket."
   type        = string
-  default     = "MULTI_REGIONAL"
+  default     = null
 }
 
 variable "bucket_policy_only" {
   description = "Enables Bucket Policy Only access to a bucket."
+  type        = bool
+  default     = true
+}
+
+variable "force_destroy" {
+  description = "Whether to delete all contained objects when the bucket is deleted."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
@morgante an initial look to address https://github.com/terraform-google-modules/terraform-google-log-export/issues/49#issuecomment-588383321. 

Few comments currently:
- Left pubsub as the current pubsub module is need of a few changes of its own first including switching to for_each from count and supporting IAM.
- Few fields are missing in the storage/bigquery modules, will add them there first.
- This will obviously require a new major release and migration script to migrate to the modules.
- Also using this PR to improve some defaults and fix #50 for storage destination.

If you can give me an initial signal I can continue working on the steps above.