### PR TITLE
Add necessary IAM permissions to Splunk Sink example

### DIFF
--- a/examples/splunk-sink/main.tf
+++ b/examples/splunk-sink/main.tf
@@ -30,3 +30,28 @@ module "destination" {
   log_sink_writer_identity = module.log_export.writer_identity
   create_subscriber        = true
 }
+
+resource "google_project_iam_custom_role" "consumer" {
+  project     = var.project_id
+  role_id     = "SplunkSink"
+  title       = "Splunk Sink"
+  description = "Grant Splunk Addon for GCP permission to see the project and PubSub Subscription"
+
+  permissions = [
+    "pubsub.subscriptions.list",
+    "resourcemanager.projects.get",
+  ]
+}
+
+resource "google_project_iam_member" "consumer" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.consumer.id
+  member  = "serviceAccount:${module.destination.pubsub_subscriber}"
+}
+
+resource "google_pubsub_subscription_iam_member" "consumer" {
+  project      = var.project_id
+  subscription = module.destination.pubsub_subscription
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${module.destination.pubsub_subscriber}"
+}


### PR DESCRIPTION
Per https://github.com/terraform-google-modules/terraform-google-log-export/issues/17, the Splunk Sink example is missing some necessary IAM permissions:

- The subscriber service account must be able to see the project and Pub/Sub  Subscription; and
- The subscriber service account must have `roles/pubsub.subscriber` on the topic subscription.

The former are implemented as a [Custom Role](https://cloud.google.com/iam/docs/creating-custom-roles) to avoid over-granting permissions to the subscriber SA.