### PR TITLE
Support for BigQuery partitioned tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ docker_test_cleanup:
 docker_test_integration:
 	docker run --rm -it \
 		-e SERVICE_ACCOUNT_JSON \
+		-e TF_VAR_project_id \
+		-e TF_VAR_org_id \
+		-e TF_VAR_folder_id \
+		-e TF_VAR_parent_resource_folder \
 		-v $(CURDIR):/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/test_integration.sh

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To use BigQuery `use_partitioned_tables` argument you must also have `unique_wri
     use_partitioned_tables = true
   }
 ```
- Enabling this option will store logs into a single table that is internally partitioned by day which can improve query performance. 
+ Enabling this option will store logs into a single table that is internally partitioned by day which can improve query performance.
 
 ### Enable API's
 In order to operate with the Service Account you must activate the following API's on the base project where the Service Account was created:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ so that all dependencies are met.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| bigquery\_options | (Optional) Options that affect sinks exporting data to BigQuery. use_partitioned_tables - (Required) Whether to use BigQuery's partition tables. | object | `"null"` | no |
 | destination\_uri | The self_link URI of the destination resource (This is available as an output coming from one of the destination submodules) | string | n/a | yes |
 | filter | The filter to apply when exporting logs. Only log entries that match the filter are exported. Default is '' which exports all logs. | string | `""` | no |
 | include\_children | Only valid if 'organization' or 'folder' is chosen as var.parent_resource.type. Determines whether or not to include children organizations/folders in the sink export. If true, logs associated with child projects are also exported; otherwise only logs relating to the provided organization/folder are included. | bool | `"false"` | no |
@@ -96,6 +97,16 @@ To use a Google Cloud Storage bucket as the destination:
 To use a BigQuery dataset as the destination, one must grant:
 - `roles/bigquery.dataEditor` on the destination project (to create a BigQuery dataset)
 
+#### BigQuery Options
+To use BigQuery `use_partitioned_tables` argument you must also have `unique_writer_identity` set to `true`.
+
+ Usage in module:
+ ```
+ bigquery_options = {
+    use_partitioned_tables = true
+  }
+```
+ Enabling this option will store logs into a single table that is internally partitioned by day which can improve query performance. 
 
 ### Enable API's
 In order to operate with the Service Account you must activate the following API's on the base project where the Service Account was created:

--- a/examples/bigquery/project/README.md
+++ b/examples/bigquery/project/README.md
@@ -7,6 +7,7 @@ This example configures a project-level log sink that feeds a bigquery dataset d
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| bigquery\_options | (Optional) Options that affect sinks exporting data to BigQuery. use_partitioned_tables - (Required) Whether to use BigQuery's partition tables. | object | `"null"` | no |
 | parent\_resource\_id | The ID of the project in which BigQuery dataset destination will be created. | string | n/a | yes |
 | project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
 

--- a/examples/bigquery/project/main.tf
+++ b/examples/bigquery/project/main.tf
@@ -21,13 +21,13 @@ resource "random_string" "suffix" {
 }
 
 module "log_export" {
-  source                 = "../../../"
-  destination_uri        = module.destination.destination_uri
-  filter                 = "resource.type = gce_instance"
-  log_sink_name          = "bigquery_project_${random_string.suffix.result}"
-  parent_resource_id     = var.parent_resource_id
-  parent_resource_type   = "project"
-  unique_writer_identity = true
+  source               = "../../../"
+  destination_uri      = module.destination.destination_uri
+  filter               = "resource.type = gce_instance"
+  log_sink_name        = "bigquery_project_${random_string.suffix.result}"
+  parent_resource_id   = var.parent_resource_id
+  parent_resource_type = "project"
+  bigquery_options     = var.bigquery_options
 }
 
 module "destination" {

--- a/examples/bigquery/project/variables.tf
+++ b/examples/bigquery/project/variables.tf
@@ -25,8 +25,9 @@ variable "parent_resource_id" {
 }
 
 variable "bigquery_options" {
-  description = "(Optional) Options that affect sinks exporting data to BigQuery. use_partitioned_tables - (Required) Whether to use BigQuery's partition tables."
-  type        = map
   default     = null
+  description = "(Optional) Options that affect sinks exporting data to BigQuery. use_partitioned_tables - (Required) Whether to use BigQuery's partition tables."
+  type = object({
+    use_partitioned_tables = bool
+  })
 }
-

--- a/examples/bigquery/project/variables.tf
+++ b/examples/bigquery/project/variables.tf
@@ -24,3 +24,9 @@ variable "parent_resource_id" {
   type        = string
 }
 
+variable "bigquery_options" {
+  description = "(Optional) Options that affect sinks exporting data to BigQuery. use_partitioned_tables - (Required) Whether to use BigQuery's partition tables."
+  type        = map
+  default     = null
+}
+

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,9 @@ locals {
   log_sink_resource_id     = local.is_project_level ? element(concat(google_logging_project_sink.sink.*.id, list("")), 0) : local.is_folder_level ? element(concat(google_logging_folder_sink.sink.*.id, list("")), 0) : local.is_org_level ? element(concat(google_logging_organization_sink.sink.*.id, list("")), 0) : local.is_billing_level ? element(concat(google_logging_billing_account_sink.sink.*.id, list("")), 0) : ""
   log_sink_resource_name   = local.is_project_level ? element(concat(google_logging_project_sink.sink.*.name, list("")), 0) : local.is_folder_level ? element(concat(google_logging_folder_sink.sink.*.name, list("")), 0) : local.is_org_level ? element(concat(google_logging_organization_sink.sink.*.name, list("")), 0) : local.is_billing_level ? element(concat(google_logging_billing_account_sink.sink.*.name, list("")), 0) : ""
   log_sink_parent_id       = local.is_project_level ? element(concat(google_logging_project_sink.sink.*.project, list("")), 0) : local.is_folder_level ? element(concat(google_logging_folder_sink.sink.*.folder, list("")), 0) : local.is_org_level ? element(concat(google_logging_organization_sink.sink.*.org_id, list("")), 0) : local.is_billing_level ? element(concat(google_logging_billing_account_sink.sink.*.billing_account, list("")), 0) : ""
+
+  # Bigquery sink option 
+  bigquery_options = var.bigquery_options == null ? [] : var.unique_writer_identity == true ? list(var.bigquery_options) : []
 }
 
 
@@ -42,6 +45,18 @@ resource "google_logging_project_sink" "sink" {
   filter                 = var.filter
   destination            = var.destination_uri
   unique_writer_identity = var.unique_writer_identity
+  dynamic "bigquery_options" {
+    for_each = local.bigquery_options
+    content {
+      use_partitioned_tables = bigquery_options.value.use_partitioned_tables
+    }
+  }
+  # dynamic "bigquery_options" {
+  #   for_each = local.bigquery_options
+  #   content {
+  #     use_partitioned_tables = local.bigquery_options[0].use_partitioned_tables
+  #   }
+  # }
 }
 
 # Folder-level
@@ -52,6 +67,12 @@ resource "google_logging_folder_sink" "sink" {
   filter           = var.filter
   include_children = var.include_children
   destination      = var.destination_uri
+  dynamic "bigquery_options" {
+    for_each = local.bigquery_options
+    content {
+      use_partitioned_tables = local.bigquery_options[0].use_partitioned_tables
+    }
+  }
 }
 
 # Org-level
@@ -62,6 +83,12 @@ resource "google_logging_organization_sink" "sink" {
   filter           = var.filter
   include_children = var.include_children
   destination      = var.destination_uri
+  dynamic "bigquery_options" {
+    for_each = local.bigquery_options
+    content {
+      use_partitioned_tables = local.bigquery_options[0].use_partitioned_tables
+    }
+  }
 }
 
 # Billing Account-level
@@ -71,4 +98,10 @@ resource "google_logging_billing_account_sink" "sink" {
   billing_account = var.parent_resource_id
   filter          = var.filter
   destination     = var.destination_uri
+  dynamic "bigquery_options" {
+    for_each = local.bigquery_options
+    content {
+      use_partitioned_tables = local.bigquery_options[0].use_partitioned_tables
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ locals {
   log_sink_resource_name   = local.is_project_level ? element(concat(google_logging_project_sink.sink.*.name, list("")), 0) : local.is_folder_level ? element(concat(google_logging_folder_sink.sink.*.name, list("")), 0) : local.is_org_level ? element(concat(google_logging_organization_sink.sink.*.name, list("")), 0) : local.is_billing_level ? element(concat(google_logging_billing_account_sink.sink.*.name, list("")), 0) : ""
   log_sink_parent_id       = local.is_project_level ? element(concat(google_logging_project_sink.sink.*.project, list("")), 0) : local.is_folder_level ? element(concat(google_logging_folder_sink.sink.*.folder, list("")), 0) : local.is_org_level ? element(concat(google_logging_organization_sink.sink.*.org_id, list("")), 0) : local.is_billing_level ? element(concat(google_logging_billing_account_sink.sink.*.billing_account, list("")), 0) : ""
 
-  # Bigquery sink options 
+  # Bigquery sink options
   bigquery_options = var.bigquery_options == null ? [] : var.unique_writer_identity == true ? list(var.bigquery_options) : []
 }
 

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ locals {
   log_sink_resource_name   = local.is_project_level ? element(concat(google_logging_project_sink.sink.*.name, list("")), 0) : local.is_folder_level ? element(concat(google_logging_folder_sink.sink.*.name, list("")), 0) : local.is_org_level ? element(concat(google_logging_organization_sink.sink.*.name, list("")), 0) : local.is_billing_level ? element(concat(google_logging_billing_account_sink.sink.*.name, list("")), 0) : ""
   log_sink_parent_id       = local.is_project_level ? element(concat(google_logging_project_sink.sink.*.project, list("")), 0) : local.is_folder_level ? element(concat(google_logging_folder_sink.sink.*.folder, list("")), 0) : local.is_org_level ? element(concat(google_logging_organization_sink.sink.*.org_id, list("")), 0) : local.is_billing_level ? element(concat(google_logging_billing_account_sink.sink.*.billing_account, list("")), 0) : ""
 
-  # Bigquery sink option 
+  # Bigquery sink options 
   bigquery_options = var.bigquery_options == null ? [] : var.unique_writer_identity == true ? list(var.bigquery_options) : []
 }
 
@@ -51,12 +51,6 @@ resource "google_logging_project_sink" "sink" {
       use_partitioned_tables = bigquery_options.value.use_partitioned_tables
     }
   }
-  # dynamic "bigquery_options" {
-  #   for_each = local.bigquery_options
-  #   content {
-  #     use_partitioned_tables = local.bigquery_options[0].use_partitioned_tables
-  #   }
-  # }
 }
 
 # Folder-level
@@ -70,7 +64,7 @@ resource "google_logging_folder_sink" "sink" {
   dynamic "bigquery_options" {
     for_each = local.bigquery_options
     content {
-      use_partitioned_tables = local.bigquery_options[0].use_partitioned_tables
+      use_partitioned_tables = bigquery_options.value.use_partitioned_tables
     }
   }
 }
@@ -86,7 +80,7 @@ resource "google_logging_organization_sink" "sink" {
   dynamic "bigquery_options" {
     for_each = local.bigquery_options
     content {
-      use_partitioned_tables = local.bigquery_options[0].use_partitioned_tables
+      use_partitioned_tables = bigquery_options.value.use_partitioned_tables
     }
   }
 }
@@ -101,7 +95,7 @@ resource "google_logging_billing_account_sink" "sink" {
   dynamic "bigquery_options" {
     for_each = local.bigquery_options
     content {
-      use_partitioned_tables = local.bigquery_options[0].use_partitioned_tables
+      use_partitioned_tables = bigquery_options.value.use_partitioned_tables
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -52,3 +52,23 @@ variable "unique_writer_identity" {
   type        = bool
   default     = false
 }
+
+# variable "bigquery_options" {
+#   description = "(Optional) Options that affect sinks exporting data to BigQuery. use_partitioned_tables - (Required) Whether to use BigQuery's partition tables."
+#   type        = map
+#   default     = null
+# }
+
+# variable "use_partitioned_tables" {
+#   description = "(Optional) Only valid if Bigquery Sink Service is chosen. Enabling this option will store logs into a single bigquery table that is internally partitioned by day which can improve query performance."
+#   type        = bool
+#   default     = false
+# }
+
+variable "bigquery_options" {
+  default     = null
+  description = "(Optional) Options that affect sinks exporting data to BigQuery. use_partitioned_tables - (Required) Whether to use BigQuery's partition tables."
+  type = object({
+    use_partitioned_tables = bool
+  })
+}

--- a/variables.tf
+++ b/variables.tf
@@ -53,18 +53,6 @@ variable "unique_writer_identity" {
   default     = false
 }
 
-# variable "bigquery_options" {
-#   description = "(Optional) Options that affect sinks exporting data to BigQuery. use_partitioned_tables - (Required) Whether to use BigQuery's partition tables."
-#   type        = map
-#   default     = null
-# }
-
-# variable "use_partitioned_tables" {
-#   description = "(Optional) Only valid if Bigquery Sink Service is chosen. Enabling this option will store logs into a single bigquery table that is internally partitioned by day which can improve query performance."
-#   type        = bool
-#   default     = false
-# }
-
 variable "bigquery_options" {
   default     = null
   description = "(Optional) Options that affect sinks exporting data to BigQuery. use_partitioned_tables - (Required) Whether to use BigQuery's partition tables."


### PR DESCRIPTION
It enables `bigquery_options` as an optional argument when using sinks exporting data to BigQuery.

The bigquery_options block supports:
`use_partitioned_tables` - (Required) Whether to use BigQuery's partition tables.

Enabling this option will store logs into a single table that is internally partitioned by day which can improve query performance.

Additionally, `bigquery_options`  requires `unique_writer_identity = true` to avoid terraform error:
```
googleapi: Error 400: Advanced sink options require using per sink service accounts. Use uniqueWriterIdentity=true to create a unique service account for this sink, badRequest
```

as described [here](https://github.com/terraform-providers/terraform-provider-google/issues/6122).