### PR TITLE
fix: relax version constraints to enable terraform 0.13.x compatibility

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,6 +16,7 @@
 driver:
   name: "terraform"
   command_timeout: 1800
+  verify_version: false
 
 verifier:
   name: "terraform"

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -38,4 +38,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/examples/bigquery/billing_account/versions.tf
+++ b/examples/bigquery/billing_account/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/bigquery/billing_account/versions.tf
+++ b/examples/bigquery/billing_account/versions.tf
@@ -19,5 +19,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/examples/bigquery/folder/versions.tf
+++ b/examples/bigquery/folder/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/bigquery/folder/versions.tf
+++ b/examples/bigquery/folder/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/examples/bigquery/organization/versions.tf
+++ b/examples/bigquery/organization/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/bigquery/organization/versions.tf
+++ b/examples/bigquery/organization/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/examples/bigquery/project/versions.tf
+++ b/examples/bigquery/project/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/bigquery/project/versions.tf
+++ b/examples/bigquery/project/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/examples/datadog-sink/main.tf
+++ b/examples/datadog-sink/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.5"
+  version = "~> 3.36.0"
 }
 
 locals {

--- a/examples/datadog-sink/versions.tf
+++ b/examples/datadog-sink/versions.tf
@@ -16,5 +16,5 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/pubsub/billing_account/versions.tf
+++ b/examples/pubsub/billing_account/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/pubsub/billing_account/versions.tf
+++ b/examples/pubsub/billing_account/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/examples/pubsub/folder/versions.tf
+++ b/examples/pubsub/folder/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/pubsub/folder/versions.tf
+++ b/examples/pubsub/folder/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/examples/pubsub/organization/versions.tf
+++ b/examples/pubsub/organization/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/pubsub/organization/versions.tf
+++ b/examples/pubsub/organization/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/examples/pubsub/project/versions.tf
+++ b/examples/pubsub/project/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/pubsub/project/versions.tf
+++ b/examples/pubsub/project/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/examples/splunk-sink/versions.tf
+++ b/examples/splunk-sink/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/splunk-sink/versions.tf
+++ b/examples/splunk-sink/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/examples/storage/billing_account/versions.tf
+++ b/examples/storage/billing_account/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/storage/billing_account/versions.tf
+++ b/examples/storage/billing_account/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/examples/storage/folder/versions.tf
+++ b/examples/storage/folder/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/storage/folder/versions.tf
+++ b/examples/storage/folder/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/examples/storage/organization/versions.tf
+++ b/examples/storage/organization/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/storage/organization/versions.tf
+++ b/examples/storage/organization/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/examples/storage/project/versions.tf
+++ b/examples/storage/project/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/examples/storage/project/versions.tf
+++ b/examples/storage/project/versions.tf
@@ -20,5 +20,5 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/modules/bigquery/versions.tf
+++ b/modules/bigquery/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = "~> 3.5"
   }

--- a/modules/pubsub/versions.tf
+++ b/modules/pubsub/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = "~> 3.5"
   }

--- a/modules/storage/versions.tf
+++ b/modules/storage/versions.tf
@@ -16,7 +16,7 @@
 
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = "~> 3.5"
   }

--- a/test/fixtures/bigquery/organization/versions.tf
+++ b/test/fixtures/bigquery/organization/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/bigquery/project/versions.tf
+++ b/test/fixtures/bigquery/project/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/computed_values/versions.tf
+++ b/test/fixtures/computed_values/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/pubsub/folder/versions.tf
+++ b/test/fixtures/pubsub/folder/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/pubsub/organization/versions.tf
+++ b/test/fixtures/pubsub/organization/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/pubsub/project/versions.tf
+++ b/test/fixtures/pubsub/project/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/storage/folder/versions.tf
+++ b/test/fixtures/storage/folder/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/storage/organization/versions.tf
+++ b/test/fixtures/storage/organization/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,7 +16,7 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 7.0"
+  version = "~> 9.0"
 
   name              = "ci-log-export"
   random_project_id = true

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -18,11 +18,12 @@ module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 9.0"
 
-  name              = "ci-log-export"
-  random_project_id = true
-  org_id            = var.org_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
+  name                 = "ci-log-export"
+  random_project_id    = true
+  org_id               = var.org_id
+  folder_id            = var.folder_id
+  billing_account      = var.billing_account
+  skip_gcloud_download = true
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }
 
 provider "google-beta" {
-  version = "~> 3.5.0"
+  version = "~> 3.36.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google = "~> 3.5"


### PR DESCRIPTION
## What is this change?

This change relaxes terraform version requirements, enabling terraform 0.13.x to use this module again.

## Why make this change?

This is a stopgap change intended to bridge the transition between terraform 0.12.x and 0.13.y.