### PR TITLE
feat!: improvements to gcs and bigquery defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0](https://www.github.com/terraform-google-modules/terraform-google-log-export/compare/v4.0.1...v4.1.0) (2020-08-28)
+
+
+### Features
+
+* Add support for BigQuery partitioned tables ([#55](https://www.github.com/terraform-google-modules/terraform-google-log-export/issues/55)) ([aa71cdb](https://www.github.com/terraform-google-modules/terraform-google-log-export/commit/aa71cdb7d88e1273123ff0364aec6d47e83691da))
+
+
+### Bug Fixes
+
+* relax version constraints to enable terraform 0.13.x compatibility ([#57](https://www.github.com/terraform-google-modules/terraform-google-log-export/issues/57)) ([0f4a832](https://www.github.com/terraform-google-modules/terraform-google-log-export/commit/0f4a8320a55134fa52f8a0b23c9a4bc1055a7ee4))
+
 ### [4.0.1](https://www.github.com/terraform-google-modules/terraform-google-log-export/compare/v4.0.0...v4.0.1) (2020-04-03)
 
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.12.1
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ so that all dependencies are met.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| bigquery\_options | (Optional) Options that affect sinks exporting data to BigQuery. use_partitioned_tables - (Required) Whether to use BigQuery's partition tables. | object | `"null"` | no |
-| destination\_uri | The self_link URI of the destination resource (This is available as an output coming from one of the destination submodules) | string | n/a | yes |
-| filter | The filter to apply when exporting logs. Only log entries that match the filter are exported. Default is '' which exports all logs. | string | `""` | no |
-| include\_children | Only valid if 'organization' or 'folder' is chosen as var.parent_resource.type. Determines whether or not to include children organizations/folders in the sink export. If true, logs associated with child projects are also exported; otherwise only logs relating to the provided organization/folder are included. | bool | `"false"` | no |
-| log\_sink\_name | The name of the log sink to be created. | string | n/a | yes |
-| parent\_resource\_id | The ID of the GCP resource in which you create the log sink. If var.parent_resource_type is set to 'project', then this is the Project ID (and etc). | string | n/a | yes |
-| parent\_resource\_type | The GCP resource in which you create the log sink. The value must not be computed, and must be one of the following: 'project', 'folder', 'billing_account', or 'organization'. | string | `"project"` | no |
-| unique\_writer\_identity | Whether or not to create a unique identity associated with this sink. If false (the default), then the writer_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for the logging sink. | bool | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| bigquery\_options | (Optional) Options that affect sinks exporting data to BigQuery. use\_partitioned\_tables - (Required) Whether to use BigQuery's partition tables. | <pre>object({<br>    use_partitioned_tables = bool<br>  })</pre> | `null` | no |
+| destination\_uri | The self\_link URI of the destination resource (This is available as an output coming from one of the destination submodules) | `string` | n/a | yes |
+| filter | The filter to apply when exporting logs. Only log entries that match the filter are exported. Default is '' which exports all logs. | `string` | `""` | no |
+| include\_children | Only valid if 'organization' or 'folder' is chosen as var.parent\_resource.type. Determines whether or not to include children organizations/folders in the sink export. If true, logs associated with child projects are also exported; otherwise only logs relating to the provided organization/folder are included. | `bool` | `false` | no |
+| log\_sink\_name | The name of the log sink to be created. | `string` | n/a | yes |
+| parent\_resource\_id | The ID of the GCP resource in which you create the log sink. If var.parent\_resource\_type is set to 'project', then this is the Project ID (and etc). | `string` | n/a | yes |
+| parent\_resource\_type | The GCP resource in which you create the log sink. The value must not be computed, and must be one of the following: 'project', 'folder', 'billing\_account', or 'organization'. | `string` | `"project"` | no |
+| unique\_writer\_identity | Whether or not to create a unique identity associated with this sink. If false (the default), then the writer\_identity used is serviceAccount:cloud-logs@system.gserviceaccount.com. If true, then a unique service account is created and used for the logging sink. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.1'

--- a/examples/bigquery/billing_account/README.md
+++ b/examples/bigquery/billing_account/README.md
@@ -6,9 +6,9 @@ This example configures a billing-account-level log sink that feeds a bigquery d
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| parent\_resource\_id | The ID of the project in which BigQuery dataset destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_id | The ID of the project in which BigQuery dataset destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/bigquery/folder/README.md
+++ b/examples/bigquery/folder/README.md
@@ -6,9 +6,9 @@ This example configures a folder-level log sink that feeds a bigquery dataset de
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| parent\_resource\_id | The ID of the project in which BigQuery dataset destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_id | The ID of the project in which BigQuery dataset destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/bigquery/organization/README.md
+++ b/examples/bigquery/organization/README.md
@@ -6,9 +6,9 @@ This example configures a organization-level log sink that feeds a bigquery data
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| parent\_resource\_id | The ID of the project in which BigQuery dataset destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_id | The ID of the project in which BigQuery dataset destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/bigquery/project/README.md
+++ b/examples/bigquery/project/README.md
@@ -6,10 +6,10 @@ This example configures a project-level log sink that feeds a bigquery dataset d
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| bigquery\_options | (Optional) Options that affect sinks exporting data to BigQuery. use_partitioned_tables - (Required) Whether to use BigQuery's partition tables. | object | `"null"` | no |
-| parent\_resource\_id | The ID of the project in which BigQuery dataset destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| bigquery\_options | (Optional) Options that affect sinks exporting data to BigQuery. use\_partitioned\_tables - (Required) Whether to use BigQuery's partition tables. | <pre>object({<br>    use_partitioned_tables = bool<br>  })</pre> | `null` | no |
+| parent\_resource\_id | The ID of the project in which BigQuery dataset destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/datadog-sink/README.md
+++ b/examples/datadog-sink/README.md
@@ -34,18 +34,18 @@ The solution helps you set up a log-streaming pipeline from Stackdriver Logging 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| key\_output\_path | The path to a directory where the JSON private key of the new Datadog service account will be created. | string | `"../datadog-sink/datadog-sa-key.json"` | no |
-| parent\_resource\_id | The ID of the project in which pubsub topic destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
-| push\_endpoint | The URL locating the endpoint to which messages should be pushed. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| key\_output\_path | The path to a directory where the JSON private key of the new Datadog service account will be created. | `string` | `"../datadog-sink/datadog-sa-key.json"` | no |
+| parent\_resource\_id | The ID of the project in which pubsub topic destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
+| push\_endpoint | The URL locating the endpoint to which messages should be pushed. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
 | datadog\_service\_account | Datadog service account email |
-| log\_writer |  |
+| log\_writer | n/a |
 | pubsub\_subscription\_name | Pub/Sub topic subscription name |
 | pubsub\_topic\_name | Pub/Sub topic name |
 | pubsub\_topic\_project | Pub/Sub topic project id |

--- a/examples/pubsub/billing_account/README.md
+++ b/examples/pubsub/billing_account/README.md
@@ -6,9 +6,9 @@ This example configures a billing-account-level log sink that feeds a pubsub top
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| parent\_resource\_id | The ID of the project in which pubsub topic destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_id | The ID of the project in which pubsub topic destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/pubsub/folder/README.md
+++ b/examples/pubsub/folder/README.md
@@ -6,9 +6,9 @@ This example configures a folder-level log sink that feeds a pubsub topic destin
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| parent\_resource\_id | The ID of the project in which pubsub topic destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_id | The ID of the project in which pubsub topic destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/pubsub/organization/README.md
+++ b/examples/pubsub/organization/README.md
@@ -6,9 +6,9 @@ This example configures a organization-level log sink that feeds a pubsub topic 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| parent\_resource\_id | The ID of the project in which pubsub topic destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_id | The ID of the project in which pubsub topic destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/pubsub/project/README.md
+++ b/examples/pubsub/project/README.md
@@ -6,9 +6,9 @@ This example configures a project-level log sink that feeds a pubsub topic desti
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| parent\_resource\_id | The ID of the project in which pubsub topic destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_id | The ID of the project in which pubsub topic destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/splunk-sink/README.md
+++ b/examples/splunk-sink/README.md
@@ -65,9 +65,9 @@ The example is for a project-level sink, but it can be easily be adapted for agg
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| parent\_resource\_id | The ID of the project in which pubsub topic destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_id | The ID of the project in which pubsub topic destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/storage/billing_account/README.md
+++ b/examples/storage/billing_account/README.md
@@ -6,9 +6,9 @@ This example configures a billing-account-level log sink that feeds a storage bu
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| parent\_resource\_id | The ID of the project in which storage bucket destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_id | The ID of the project in which storage bucket destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/storage/folder/README.md
+++ b/examples/storage/folder/README.md
@@ -6,9 +6,9 @@ This example configures a folder-level log sink that feeds a storage bucket dest
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| parent\_resource\_id | The ID of the project in which storage bucket destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_id | The ID of the project in which storage bucket destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/storage/organization/README.md
+++ b/examples/storage/organization/README.md
@@ -6,9 +6,9 @@ This example configures a organization-level log sink that feeds a storage bucke
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| parent\_resource\_id | The ID of the project in which storage bucket destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_id | The ID of the project in which storage bucket destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/storage/project/README.md
+++ b/examples/storage/project/README.md
@@ -6,9 +6,9 @@ This example configures a project-level log sink that feeds a storage bucket des
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| parent\_resource\_id | The ID of the project in which storage bucket destination will be created. | string | n/a | yes |
-| project\_id | The ID of the project in which the log export will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_id | The ID of the project in which storage bucket destination will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which the log export will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/bigquery/README.md
+++ b/modules/bigquery/README.md
@@ -35,15 +35,15 @@ so that all dependencies are met.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| dataset\_name | The name of the bigquery dataset to be created and used for log entries matching the filter. | string | n/a | yes |
-| default\_table\_expiration\_ms | Default table expiration time (in ms) | number | `"3600000"` | no |
-| delete\_contents\_on\_destroy | (Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present. | bool | `"false"` | no |
-| description | A use-friendly description of the dataset | string | `"Log export dataset"` | no |
-| labels | Dataset labels | map(string) | `<map>` | no |
-| location | The location of the storage bucket. | string | `"US"` | no |
-| log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | string | n/a | yes |
-| project\_id | The ID of the project in which the bigquery dataset will be created. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| dataset\_name | The name of the bigquery dataset to be created and used for log entries matching the filter. | `string` | n/a | yes |
+| default\_table\_expiration\_ms | Default table expiration time (in ms) | `number` | `3600000` | no |
+| delete\_contents\_on\_destroy | (Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present. | `bool` | `false` | no |
+| description | A use-friendly description of the dataset | `string` | `"Log export dataset"` | no |
+| labels | Dataset labels | `map(string)` | `{}` | no |
+| location | The location of the storage bucket. | `string` | `"US"` | no |
+| log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | `string` | n/a | yes |
+| project\_id | The ID of the project in which the bigquery dataset will be created. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -54,6 +54,6 @@ so that all dependencies are met.
 | project | The project in which the bigquery dataset was created. |
 | resource\_id | The resource id for the destination bigquery dataset |
 | resource\_name | The resource name for the destination bigquery dataset |
-| self\_link | The self_link URI for the destination bigquery dataset |
+| self\_link | The self\_link URI for the destination bigquery dataset |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/bigquery/README.md
+++ b/modules/bigquery/README.md
@@ -38,7 +38,7 @@ so that all dependencies are met.
 |------|-------------|:----:|:-----:|:-----:|
 | dataset\_name | The name of the bigquery dataset to be created and used for log entries matching the filter. | string | n/a | yes |
 | default\_table\_expiration\_ms | Default table expiration time (in ms) | number | `"3600000"` | no |
-| delete\_contents\_on\_destroy | (Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present. | bool | `"true"` | no |
+| delete\_contents\_on\_destroy | (Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present. | bool | `"false"` | no |
 | description | A use-friendly description of the dataset | string | `"Log export dataset"` | no |
 | labels | Dataset labels | map(string) | `<map>` | no |
 | location | The location of the storage bucket. | string | `"US"` | no |

--- a/modules/bigquery/variables.tf
+++ b/modules/bigquery/variables.tf
@@ -38,7 +38,7 @@ variable "location" {
 variable "delete_contents_on_destroy" {
   description = "(Optional) If set to true, delete all the tables in the dataset when destroying the resource; otherwise, destroying the resource will fail if tables are present."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "default_table_expiration_ms" {

--- a/modules/pubsub/README.md
+++ b/modules/pubsub/README.md
@@ -36,14 +36,14 @@ so that all dependencies are met.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| create\_push\_subscriber | Whether to add a push configuration to the subcription. If 'true', a push subscription is created along with a service account that is granted roles/pubsub.subscriber and roles/pubsub.viewer to the topic. | bool | `"false"` | no |
-| create\_subscriber | Whether to create a subscription to the topic that was created and used for log entries matching the filter. If 'true', a pull subscription is created along with a service account that is granted roles/pubsub.subscriber and roles/pubsub.viewer to the topic. | bool | `"false"` | no |
-| log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | string | n/a | yes |
-| project\_id | The ID of the project in which the pubsub topic will be created. | string | n/a | yes |
-| push\_endpoint | The URL locating the endpoint to which messages should be pushed. | string | `""` | no |
-| topic\_labels | A set of key/value label pairs to assign to the pubsub topic. | map(string) | `<map>` | no |
-| topic\_name | The name of the pubsub topic to be created and used for log entries matching the filter. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| create\_push\_subscriber | Whether to add a push configuration to the subcription. If 'true', a push subscription is created along with a service account that is granted roles/pubsub.subscriber and roles/pubsub.viewer to the topic. | `bool` | `false` | no |
+| create\_subscriber | Whether to create a subscription to the topic that was created and used for log entries matching the filter. If 'true', a pull subscription is created along with a service account that is granted roles/pubsub.subscriber and roles/pubsub.viewer to the topic. | `bool` | `false` | no |
+| log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | `string` | n/a | yes |
+| project\_id | The ID of the project in which the pubsub topic will be created. | `string` | n/a | yes |
+| push\_endpoint | The URL locating the endpoint to which messages should be pushed. | `string` | `""` | no |
+| topic\_labels | A set of key/value label pairs to assign to the pubsub topic. | `map(string)` | `{}` | no |
+| topic\_name | The name of the pubsub topic to be created and used for log entries matching the filter. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -37,11 +37,12 @@ so that all dependencies are met.
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | expiration\_days | Object expiration time. If unset logs will never be deleted. | number | `"null"` | no |
+| force\_destroy | When deleting a bucket, this boolean option will delete all contained objects. | bool | `"false"` | no |
 | location | The location of the storage bucket. | string | `"US"` | no |
 | log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | string | n/a | yes |
 | project\_id | The ID of the project in which the storage bucket will be created. | string | n/a | yes |
 | storage\_bucket\_name | The name of the storage bucket to be created and used for log entries matching the filter. | string | n/a | yes |
-| storage\_class | The storage class of the storage bucket. | string | `"MULTI_REGIONAL"` | no |
+| storage\_class | The storage class of the storage bucket. | string | `"null"` | no |
 | uniform\_bucket\_level\_access | Enables Uniform bucket-level access access to a bucket. | bool | `"true"` | no |
 
 ## Outputs

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -36,12 +36,12 @@ so that all dependencies are met.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| bucket\_policy\_only | Enables Bucket Policy Only access to a bucket. | bool | `"false"` | no |
 | location | The location of the storage bucket. | string | `"US"` | no |
 | log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | string | n/a | yes |
 | project\_id | The ID of the project in which the storage bucket will be created. | string | n/a | yes |
 | storage\_bucket\_name | The name of the storage bucket to be created and used for log entries matching the filter. | string | n/a | yes |
 | storage\_class | The storage class of the storage bucket. | string | `"MULTI_REGIONAL"` | no |
+| uniform\_bucket\_level\_access | Enables Uniform bucket-level access access to a bucket. | bool | `"true"` | no |
 
 ## Outputs
 

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -35,15 +35,15 @@ so that all dependencies are met.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| expiration\_days | Object expiration time. If unset logs will never be deleted. | number | `"null"` | no |
-| force\_destroy | When deleting a bucket, this boolean option will delete all contained objects. | bool | `"false"` | no |
-| location | The location of the storage bucket. | string | `"US"` | no |
-| log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | string | n/a | yes |
-| project\_id | The ID of the project in which the storage bucket will be created. | string | n/a | yes |
-| storage\_bucket\_name | The name of the storage bucket to be created and used for log entries matching the filter. | string | n/a | yes |
-| storage\_class | The storage class of the storage bucket. | string | `"null"` | no |
-| uniform\_bucket\_level\_access | Enables Uniform bucket-level access access to a bucket. | bool | `"true"` | no |
+|------|-------------|------|---------|:--------:|
+| expiration\_days | Object expiration time. If unset logs will never be deleted. | `number` | `null` | no |
+| force\_destroy | When deleting a bucket, this boolean option will delete all contained objects. | `bool` | `false` | no |
+| location | The location of the storage bucket. | `string` | `"US"` | no |
+| log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | `string` | n/a | yes |
+| project\_id | The ID of the project in which the storage bucket will be created. | `string` | n/a | yes |
+| storage\_bucket\_name | The name of the storage bucket to be created and used for log entries matching the filter. | `string` | n/a | yes |
+| storage\_class | The storage class of the storage bucket. | `string` | `null` | no |
+| uniform\_bucket\_level\_access | Enables Uniform bucket-level access access to a bucket. | `bool` | `true` | no |
 
 ## Outputs
 
@@ -54,6 +54,6 @@ so that all dependencies are met.
 | project | The project in which the storage bucket was created. |
 | resource\_id | The resource id for the destination storage bucket |
 | resource\_name | The resource name for the destination storage bucket |
-| self\_link | The self_link URI for the destination storage bucket |
+| self\_link | The self\_link URI for the destination storage bucket |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -36,7 +36,7 @@ resource "google_storage_bucket" "bucket" {
   project                     = google_project_service.enable_destination_api.project
   storage_class               = var.storage_class
   location                    = var.location
-  uniform_bucket_level_access = var.bucket_policy_only
+  uniform_bucket_level_access = var.uniform_bucket_level_access
 }
 
 #--------------------------------#

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -32,12 +32,11 @@ resource "google_project_service" "enable_destination_api" {
 # Storage bucket #
 #----------------#
 resource "google_storage_bucket" "bucket" {
-  name               = var.storage_bucket_name
-  project            = google_project_service.enable_destination_api.project
-  storage_class      = var.storage_class
-  location           = var.location
-  force_destroy      = true
-  bucket_policy_only = var.bucket_policy_only
+  name                        = var.storage_bucket_name
+  project                     = google_project_service.enable_destination_api.project
+  storage_class               = var.storage_class
+  location                    = var.location
+  uniform_bucket_level_access = var.bucket_policy_only
 }
 
 #--------------------------------#
@@ -48,4 +47,3 @@ resource "google_storage_bucket_iam_member" "storage_sink_member" {
   role   = "roles/storage.objectCreator"
   member = var.log_sink_writer_identity
 }
-

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -36,6 +36,7 @@ resource "google_storage_bucket" "bucket" {
   project                     = google_project_service.enable_destination_api.project
   storage_class               = var.storage_class
   location                    = var.location
+  force_destroy               = var.force_destroy
   uniform_bucket_level_access = var.uniform_bucket_level_access
 
   dynamic "lifecycle_rule" {

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -44,5 +44,5 @@ variable "storage_class" {
 variable "bucket_policy_only" {
   description = "Enables Bucket Policy Only access to a bucket."
   type        = bool
-  default     = false
+  default     = true
 }

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -41,8 +41,8 @@ variable "storage_class" {
   default     = "MULTI_REGIONAL"
 }
 
-variable "bucket_policy_only" {
-  description = "Enables Bucket Policy Only access to a bucket."
+variable "uniform_bucket_level_access" {
+  description = "Enables Uniform bucket-level access access to a bucket."
   type        = bool
   default     = true
 }

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -38,7 +38,7 @@ variable "location" {
 variable "storage_class" {
   description = "The storage class of the storage bucket."
   type        = string
-  default     = "MULTI_REGIONAL"
+  default     = null
 }
 
 variable "uniform_bucket_level_access" {
@@ -51,4 +51,10 @@ variable "expiration_days" {
   description = "Object expiration time. If unset logs will never be deleted."
   type        = number
   default     = null
+}
+
+variable "force_destroy" {
+  description = "When deleting a bucket, this boolean option will delete all contained objects."
+  type        = bool
+  default     = false
 }

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 3.36.0"
+  version = "~> 3.38.0"
 }
 
 provider "google-beta" {
-  version = "~> 3.36.0"
+  version = "~> 3.38.0"
 }


### PR DESCRIPTION
- `bucket_policy_only` is deprecated. Rename to `uniform_bucket_level_access`. Also default this to true as that is a best practice.
- don't set force_destroy to true. Audit logs are sensitive resources that should not be accidentally deleted.
- don't set storage_class to legacy MULTI_REGIONAL as recommended in https://cloud.google.com/storage/docs/storage-classes#legacy. null will default to 'STANDARD'.

Fix #50
Fix #51 

This is a breaking change.