### PR TITLE
feat: Add storage module versioning support

### DIFF
--- a/examples/storage/billing_account/README.md
+++ b/examples/storage/billing_account/README.md
@@ -1,6 +1,6 @@
 # Log Export: Storage destination at Billing Account level
 
-This example configures a billing-account-level log sink that feeds a storage bucket destination
+This example configures a billing-account-level log sink that feeds a storage bucket destination. Storage bucket versioning is turned on to mitigate possible modify or delete log events.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/examples/storage/billing_account/main.tf
+++ b/examples/storage/billing_account/main.tf
@@ -28,5 +28,6 @@ module "destination" {
   project_id               = var.project_id
   storage_bucket_name      = "storage_example_bucket"
   log_sink_writer_identity = module.log_export.writer_identity
+  versioning               = true
 }
 

--- a/examples/storage/organization/README.md
+++ b/examples/storage/organization/README.md
@@ -1,6 +1,6 @@
 # Log Export: Storage destination at Organization level
 
-This example configures a organization-level log sink that feeds a storage bucket destination
+This example configures a organization-level log sink that feeds a storage bucket destination. Storage bucket versioning is turned on to mitigate possible modify or delete log events.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/examples/storage/organization/main.tf
+++ b/examples/storage/organization/main.tf
@@ -36,5 +36,6 @@ module "destination" {
   project_id               = var.project_id
   storage_bucket_name      = "storage_org_${random_string.suffix.result}"
   log_sink_writer_identity = module.log_export.writer_identity
+  versioning               = true
 }
 

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -45,6 +45,7 @@ so that all dependencies are met.
 | storage\_bucket\_name | The name of the storage bucket to be created and used for log entries matching the filter. | `string` | n/a | yes |
 | storage\_class | The storage class of the storage bucket. | `string` | `"STANDARD"` | no |
 | uniform\_bucket\_level\_access | Enables Uniform bucket-level access to a bucket. | `bool` | `true` | no |
+| versioning | Toggles bucket versioning, ability to retain a non-current object version when the live object version gets replaced or deleted. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -39,6 +39,10 @@ resource "google_storage_bucket" "bucket" {
   force_destroy               = var.force_destroy
   uniform_bucket_level_access = var.uniform_bucket_level_access
 
+  versioning {
+    enabled = var.versioning
+  }
+
   dynamic "lifecycle_rule" {
     for_each = var.expiration_days == null ? [] : [var.expiration_days]
     content {

--- a/modules/storage/variables.tf
+++ b/modules/storage/variables.tf
@@ -67,3 +67,9 @@ variable "retention_policy" {
   })
   default = null
 }
+
+variable "versioning" {
+  description = "Toggles bucket versioning, ability to retain a non-current object version when the live object version gets replaced or deleted."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This PR adds support for object versioning in `storage` module. Versioning is enabled for two log sink examples - `organization-level` and `billing-account-level`. Should this be enabled or disabled for all examples, ready to change it accordingly.

This closes https://github.com/terraform-google-modules/terraform-google-log-export/issues/70 and https://github.com/terraform-google-modules/terraform-example-foundation/issues/274.

Thanks.