### PR TITLE
Addresses Issue #83 (Optional subscriber_id Variable)

### DIFF
--- a/modules/pubsub/README.md
+++ b/modules/pubsub/README.md
@@ -42,6 +42,7 @@ so that all dependencies are met.
 | log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | `string` | n/a | yes |
 | project\_id | The ID of the project in which the pubsub topic will be created. | `string` | n/a | yes |
 | push\_endpoint | The URL locating the endpoint to which messages should be pushed. | `string` | `""` | no |
+| subscriber\_id | The ID to give the pubsub pull subscriber service account (optional). | `string` | `""` | no |
 | subscription\_labels | A set of key/value label pairs to assign to the pubsub subscription. | `map(string)` | `{}` | no |
 | topic\_labels | A set of key/value label pairs to assign to the pubsub topic. | `map(string)` | `{}` | no |
 | topic\_name | The name of the pubsub topic to be created and used for log entries matching the filter. | `string` | n/a | yes |

--- a/modules/pubsub/main.tf
+++ b/modules/pubsub/main.tf
@@ -32,6 +32,7 @@ locals {
     concat(google_pubsub_subscription.pubsub_push_subscription.*.id, [""]),
     0,
   )
+  subscriber_id = var.subscriber_id == "" ? "${local.topic_name}-subscriber" : var.subscriber_id
 }
 
 #----------------#
@@ -67,7 +68,7 @@ resource "google_pubsub_topic_iam_member" "pubsub_sink_member" {
 #-----------------------------------------------#
 resource "google_service_account" "pubsub_subscriber" {
   count        = var.create_subscriber ? 1 : 0
-  account_id   = "${local.topic_name}-subscriber"
+  account_id   = local.subscriber_id
   display_name = "${local.topic_name} Topic Subscriber"
   project      = var.project_id
 }

--- a/modules/pubsub/variables.tf
+++ b/modules/pubsub/variables.tf
@@ -20,6 +20,12 @@ variable "create_subscriber" {
   default     = false
 }
 
+variable "subscriber_id" {
+  description = "The ID to give the pubsub pull subscriber service account (optional)."
+  type        = string
+  default     = ""
+}
+
 variable "subscription_labels" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
This adds an optional variable to override the name of the service account created along with the (optional) subscription.

Fixes #83.