### PR TITLE
BigQuery Log Alerting Fixes

### DIFF
--- a/examples/bq-log-alerting/README.md
+++ b/examples/bq-log-alerting/README.md
@@ -11,18 +11,18 @@ To run this example, you'll need:
   - "logName: /logs/cloudaudit.googleapis.com%2Factivity"
   - "logName: /logs/cloudaudit.googleapis.com%2Fdata_access"
   - "logName: /logs/compute.googleapis.com%2Fvpc_flows"
-- A Terraform Service Account with the [IAM Roles](../../../modules/bq-log-alerting/README.md) listed in the submodule documentation.
-- To enable in the logging project the [APIs](../../../modules/bq-log-alerting/README.md) listed in the submodule documentation.
+- A Terraform Service Account with the [IAM Roles](../../modules/bq-log-alerting/README.md#iam-roles) listed in the submodule documentation.
+- To enable in the logging project the [APIs](../../modules/bq-log-alerting/README.md#apis) listed in the submodule documentation.
 - To enable in the logging project [Google App Engine](https://cloud.google.com/appengine).
 To enable it manually use:
 
 ```shell
 gcloud app create \
---region=<REGION> \
+--region=<GAE_LOCATION> \
 --project=<LOGGING_PROJECT>
 ```
 
-**Note 1:** The selected Google App Engine region cannot be changed after creation and only project Owners (`role/owner`) can enable Google App Engine.
+**Note 1:** The selected [Google App Engine location](https://cloud.google.com/appengine/docs/locations) cannot be changed after creation and only project Owners (`role/owner`) can enable Google App Engine.
 
 **Note 2:** On deployment a Security Command Center Source called "BQ Log Alerts" will be created. If this source already exist due to the submodule been deployed at least once before, you need to obtain the existing Source name to be informed in the terraform variable **source_name**.
 Run:
@@ -49,9 +49,10 @@ The [terraform-example-foundation](https://github.com/terraform-google-modules/t
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| bigquery\_location | Location for BigQuery resources. | `string` | `"US"` | no |
+| function\_region | Region for the Cloud function resources. | `string` | n/a | yes |
 | logging\_project | The project to deploy the submodule | `string` | n/a | yes |
 | org\_id | The organization ID for the associated services | `string` | n/a | yes |
-| region | Region for BigQuery resources. | `string` | n/a | yes |
 | source\_name | The Security Command Center Source name for the "BQ Log Alerts" Source if the source had been created before. The format is `organizations/<ORG_ID>/sources/<SOURCE_ID>` | `string` | `""` | no |
 
 ## Outputs

--- a/examples/bq-log-alerting/README.md
+++ b/examples/bq-log-alerting/README.md
@@ -7,7 +7,7 @@ This example deploys the BigQuery Log Alerting submodule in an existing project.
 To run this example, you'll need:
 
 - An existing "logging" project
-- A [Log export](https://github.com/terraform-google-modules/terraform-google-log-export) with a [BigQuery destination](https://github.com/terraform-google-modules/terraform-google-log-export/tree/master/modules/bigquery) in the logging project. The export filter should include at least:
+- A [Log export](https://github.com/terraform-google-modules/terraform-google-log-export) with a [BigQuery destination](https://github.com/terraform-google-modules/terraform-google-log-export/tree/master/modules/bigquery) created in the logging project. The export filter should include at least:
   - "logName: /logs/cloudaudit.googleapis.com%2Factivity"
   - "logName: /logs/cloudaudit.googleapis.com%2Fdata_access"
   - "logName: /logs/compute.googleapis.com%2Fvpc_flows"

--- a/examples/bq-log-alerting/README.md
+++ b/examples/bq-log-alerting/README.md
@@ -2,29 +2,17 @@
 
 This example deploys the BigQuery Log Alerting submodule in an existing project.
 
-## Prerequisites
+## Requirements
 
-To run this example, you'll need:
+Make sure you have the requirements listed in the submodule [README](../../modules/bq-log-alerting/README.md) Before running this example.
 
-- An existing "logging" project
-- A [Log export](https://github.com/terraform-google-modules/terraform-google-log-export) with a [BigQuery destination](https://github.com/terraform-google-modules/terraform-google-log-export/tree/master/modules/bigquery) created in the logging project. The export filter should include at least:
-  - "logName: /logs/cloudaudit.googleapis.com%2Factivity"
-  - "logName: /logs/cloudaudit.googleapis.com%2Fdata_access"
-  - "logName: /logs/compute.googleapis.com%2Fvpc_flows"
-- A Terraform Service Account with the [IAM Roles](../../modules/bq-log-alerting/README.md#iam-roles) listed in the submodule documentation.
-- To enable in the logging project the [APIs](../../modules/bq-log-alerting/README.md#apis) listed in the submodule documentation.
-- To enable in the logging project [Google App Engine](https://cloud.google.com/appengine).
-To enable it manually use:
+## Instructions
 
-```shell
-gcloud app create \
---region=<GAE_LOCATION> \
---project=<LOGGING_PROJECT>
-```
+### Check if the Source "BQ Log Alerts" exist
 
-**Note 1:** The selected [Google App Engine location](https://cloud.google.com/appengine/docs/locations) cannot be changed after creation and only project Owners (`role/owner`) can enable Google App Engine.
-
-**Note 2:** On deployment a Security Command Center Source called "BQ Log Alerts" will be created. If this source already exist due to the submodule been deployed at least once before, you need to obtain the existing Source name to be informed in the terraform variable **source_name**.
+On deployment a Security Command Center Source called "BQ Log Alerts" will be created.
+If this source already exist due to the submodule been deployed at least once before,
+you need to obtain the existing Source name to be informed in the terraform variable **source_name**.
 Run:
 
 ```shell
@@ -36,13 +24,49 @@ gcloud scc sources describe <ORG_ID> \
 
 The source name format is `organizations/<ORG_ID>/sources/<SOURCE_ID>`.
 
-The [terraform-example-foundation](https://github.com/terraform-google-modules/terraform-example-foundation) can be used as a reference for the creation of the logging project, the service account and the log export.
+### Activate impersonation of the service account
 
-## Instructions
+To activate impersonation on the service account you can:
+
+Set the `gcloud` config auth impersonation:
+
+```shell
+gcloud config set auth/impersonate_service_account <TERRAFORM_SERVICE_ACCOUNT_EMAIL>
+```
+
+Or
+
+Change the [versions.tf](./versions.tf) file to set [impersonation on the provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#impersonate_service_account):
+
+From
+
+```terraform
+provider "google" {
+  version = "~> 3.53.0"
+}
+
+```
+
+To
+
+```terraform
+provider "google" {
+  version = "~> 3.53.0"
+
+  impersonate_service_account = "<TERRAFORM_SERVICE_ACCOUNT_EMAIL>"
+}
+
+```
+
+### Run Terraform
 
 1. Run `terraform init`
 1. Run `terraform plan` provide the requested variables values and review the output.
 1. Run `terraform apply`
+
+### Deploy Use Cases
+
+Deploy the [Use Cases](../../modules/bq-log-alerting/use-cases) that will provide the data for the Security Command Center findings.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/examples/bq-log-alerting/README.md
+++ b/examples/bq-log-alerting/README.md
@@ -49,8 +49,8 @@ The [terraform-example-foundation](https://github.com/terraform-google-modules/t
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| bigquery\_location | Location for BigQuery resources. | `string` | `"US"` | no |
-| function\_region | Region for the Cloud function resources. | `string` | n/a | yes |
+| bigquery\_location | Location for BigQuery resources. See https://cloud.google.com/bigquery/docs/locations for valid values. | `string` | `"US"` | no |
+| function\_region | Region for the Cloud function resources. See https://cloud.google.com/functions/docs/locations for valid values. | `string` | n/a | yes |
 | logging\_project | The project to deploy the submodule | `string` | n/a | yes |
 | org\_id | The organization ID for the associated services | `string` | n/a | yes |
 | source\_name | The Security Command Center Source name for the "BQ Log Alerts" Source if the source had been created before. The format is `organizations/<ORG_ID>/sources/<SOURCE_ID>` | `string` | `""` | no |

--- a/examples/bq-log-alerting/main.tf
+++ b/examples/bq-log-alerting/main.tf
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-/*****************************
-  Provider configuration
- ****************************/
-provider "google" {
-  version = "~> 3.30"
-}
-
 module "bq-log-alerting" {
-  source          = "../..//modules/bq-log-alerting"
-  logging_project = var.logging_project
-  region          = var.region
-  org_id          = var.org_id
-  source_name     = var.source_name
-  dry_run         = false
+  source            = "../..//modules/bq-log-alerting"
+  logging_project   = var.logging_project
+  bigquery_location = var.bigquery_location
+  function_region   = var.function_region
+  org_id            = var.org_id
+  source_name       = var.source_name
+  dry_run           = false
 }

--- a/examples/bq-log-alerting/variables.tf
+++ b/examples/bq-log-alerting/variables.tf
@@ -20,12 +20,12 @@ variable "org_id" {
 }
 
 variable "function_region" {
-  description = "Region for the Cloud function resources."
+  description = "Region for the Cloud function resources. See https://cloud.google.com/functions/docs/locations for valid values."
   type        = string
 }
 
 variable "bigquery_location" {
-  description = "Location for BigQuery resources."
+  description = "Location for BigQuery resources. See https://cloud.google.com/bigquery/docs/locations for valid values."
   type        = string
   default     = "US"
 }

--- a/examples/bq-log-alerting/variables.tf
+++ b/examples/bq-log-alerting/variables.tf
@@ -19,9 +19,15 @@ variable "org_id" {
   type        = string
 }
 
-variable "region" {
-  description = "Region for BigQuery resources."
+variable "function_region" {
+  description = "Region for the Cloud function resources."
   type        = string
+}
+
+variable "bigquery_location" {
+  description = "Location for BigQuery resources."
+  type        = string
+  default     = "US"
 }
 
 variable "source_name" {

--- a/examples/bq-log-alerting/versions.tf
+++ b/examples/bq-log-alerting/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.13"
+  required_version = ">=0.12.6"
 }
 
 provider "google" {

--- a/examples/bq-log-alerting/versions.tf
+++ b/examples/bq-log-alerting/versions.tf
@@ -15,5 +15,9 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.13"
+}
+
+provider "google" {
+  version = "~> 3.53.0"
 }

--- a/examples/bq-log-alerting/versions.tf
+++ b/examples/bq-log-alerting/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.13.6"
+  required_version = ">=0.12.6"
 }
 
 provider "google" {

--- a/examples/bq-log-alerting/versions.tf
+++ b/examples/bq-log-alerting/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6"
+  required_version = ">=0.13.6"
 }
 
 provider "google" {

--- a/modules/bq-log-alerting/README.md
+++ b/modules/bq-log-alerting/README.md
@@ -154,10 +154,10 @@ following APIs enabled:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| bigquery\_location | Location for BigQuery resources. | `string` | `"US"` | no |
+| bigquery\_location | Location for BigQuery resources. See https://cloud.google.com/bigquery/docs/locations for valid values. | `string` | `"US"` | no |
 | dry\_run | Enable dry\_run execution of the Cloud Function. If is true it will just print the object the would be converted as a finding | `bool` | `false` | no |
 | function\_memory | The amount of memory in megabytes allotted for the Cloud function to use. | `number` | `"256"` | no |
-| function\_region | Region for the Cloud function resources. | `string` | n/a | yes |
+| function\_region | Region for the Cloud function resources. See https://cloud.google.com/functions/docs/locations for valid values. | `string` | n/a | yes |
 | function\_timeout | The amount of time in seconds allotted for the execution of the function. | `number` | `"540"` | no |
 | job\_schedule | The schedule on which the job will be executed in the unix-cron string format (https://cloud.google.com/scheduler/docs/configuring/cron-job-schedules#defining_the_job_schedule). Defaults to 15 minutes. | `string` | `"*/15 * * * *"` | no |
 | logging\_project | The project to deploy the tool. | `string` | n/a | yes |

--- a/modules/bq-log-alerting/README.md
+++ b/modules/bq-log-alerting/README.md
@@ -43,6 +43,7 @@ for this to work, the Security Command Center API needs to be enabled in the Ter
 
 ## Usage
 
+The [examples](../../examples) directory contain a directory with an example for deploying the BigQuery Log Alerting tool.
 Basic usage of this submodule is as follows:
 
 ```hcl
@@ -55,8 +56,6 @@ module "bq-log-alerting" {
   dry_run           = false
 }
 ```
-
-The [examples](../../examples) directory contain an example for deploying the BigQuery Log Alerting tool.
 
 **Note 1:** On deployment, a Security Command Center Source called "BQ Log Alerts" will be created. If this source already exist due to the tool been deployed at least once before in the organization, obtain the existing Source name to be used in the Terraform variable **source_name**. Run:
 
@@ -93,12 +92,11 @@ order to invoke this submodule.
 ### General
 
 * You need an existing "logging" project.
-* A [Log export](https://github.com/terraform-google-modules/terraform-google-log-export) with a [BigQuery destination](https://github.com/terraform-google-modules/terraform-google-log-export/tree/master/modules/bigquery) in the logging project. The export filter should include at least:
+* A [Log export](https://github.com/terraform-google-modules/terraform-google-log-export) with a [BigQuery destination](https://github.com/terraform-google-modules/terraform-google-log-export/tree/master/modules/bigquery) created in the logging project. The export filter should include at least:
   * "logName: /logs/cloudaudit.googleapis.com%2Factivity"
   * "logName: /logs/cloudaudit.googleapis.com%2Fdata_access"
   * "logName: /logs/compute.googleapis.com%2Fvpc_flows"
-* It is necessary to use a service account to authenticate the Google Terraform provider to be able to create the Security Command Center "BQ Log Alerts" Source.
-This is a restriction of the Security Command Center API
+* In order to execute this submodule you must configure and use a Service Account.
 * [Google App Engine](https://cloud.google.com/appengine) must be enabled in the logging project. To enable it manually use:
 
 ```shell
@@ -124,8 +122,6 @@ The service account which will be used to invoke this submodule must have the fo
 * Organization level
   * Security Admin: `roles/iam.securityAdmin`
   * Security Center Sources Editor: `roles/securitycenter.sourcesEditor`
-
-If you are deploying this submodule in the logging project of the Terraform Example Foundation using the Terraform service account created in the Foundation, it already has all the necessary permissions in the logging project.
 
 ### APIs
 

--- a/modules/bq-log-alerting/README.md
+++ b/modules/bq-log-alerting/README.md
@@ -47,11 +47,12 @@ Basic usage of this submodule is as follows:
 
 ```hcl
 module "bq-log-alerting" {
-  source          = "terraform-google-modules/log-export/google//modules/bq-log-alerting"
-  logging_project = <LOGGING_PROJECT>
-  region          = <REGION>
-  org_id          = <ORG_ID>
-  dry_run         = false
+  source            = "terraform-google-modules/log-export/google//modules/bq-log-alerting"
+  logging_project   = <LOGGING_PROJECT>
+  bigquery_location = <BIGQUERY_LOCATION>
+  function_region   = <CLOUD_FUNCTION_REGION>
+  org_id            = <ORG_ID>
+  dry_run           = false
 }
 ```
 
@@ -102,11 +103,11 @@ This is a restriction of the Security Command Center API
 
 ```shell
 gcloud app create \
---region=<REGION> \
+--region=<GAE_LOCATION> \
 --project=<LOGGING_PROJECT>
 ```
 
-**Note:** The selected region cannot be changed after creation and only project Owners (`role/owner`) can enable Google App Engine. If you are not an Owner of the project, but the service account is, you can add `--impersonate-service-account=<TERRAFORM_SERVICE_ACCOUNT_EMAIL>` to the command like it was used when the Security Command Center source was created.
+**Note:** The selected [Google App Engine location](https://cloud.google.com/appengine/docs/locations) cannot be changed after creation and only project Owners (`role/owner`) can enable Google App Engine. If you are not an Owner of the project, but the service account is, you can add `--impersonate-service-account=<TERRAFORM_SERVICE_ACCOUNT_EMAIL>` to the command like it was used when the Security Command Center source was created.
 
 ### IAM Roles
 
@@ -145,7 +146,7 @@ following APIs enabled:
 
 ### Software Dependencies
 
-* [Terraform][terraform-site] v0.12
+* [Terraform][terraform-site] v0.13
 * [Terraform Provider for Google Cloud Platform][terraform-provider-gcp-site] v3.25.0
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -153,13 +154,14 @@ following APIs enabled:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| bigquery\_location | Location for BigQuery resources. | `string` | `"US"` | no |
 | dry\_run | Enable dry\_run execution of the Cloud Function. If is true it will just print the object the would be converted as a finding | `bool` | `false` | no |
 | function\_memory | The amount of memory in megabytes allotted for the Cloud function to use. | `number` | `"256"` | no |
+| function\_region | Region for the Cloud function resources. | `string` | n/a | yes |
 | function\_timeout | The amount of time in seconds allotted for the execution of the function. | `number` | `"540"` | no |
 | job\_schedule | The schedule on which the job will be executed in the unix-cron string format (https://cloud.google.com/scheduler/docs/configuring/cron-job-schedules#defining_the_job_schedule). Defaults to 15 minutes. | `string` | `"*/15 * * * *"` | no |
 | logging\_project | The project to deploy the tool. | `string` | n/a | yes |
 | org\_id | The organization ID for the associated services | `string` | n/a | yes |
-| region | Region for BigQuery resources. | `string` | n/a | yes |
 | source\_name | The Security Command Center Source name for the "BQ Log Alerts" Source if the source had been created before. The format is `organizations/<ORG_ID>/sources/<SOURCE_ID>` | `string` | `""` | no |
 | time\_window\_quantity | The time window quantity used in the query in the view in BigQuery. | `string` | `"20"` | no |
 | time\_window\_unit | The time window unit used in the query in the view in BigQuery. Valid values are 'MICROSECOND', 'MILLISECOND', 'SECOND', 'MINUTE', 'HOUR' | `string` | `"MINUTE"` | no |

--- a/modules/bq-log-alerting/main.tf
+++ b/modules/bq-log-alerting/main.tf
@@ -69,7 +69,7 @@ resource "google_bigquery_dataset" "views_dataset" {
   dataset_id    = "views"
   friendly_name = "Log Views"
   description   = "Log view dataset"
-  location      = "US"
+  location      = var.bigquery_location
   project       = var.logging_project
 
   labels = {
@@ -97,7 +97,7 @@ module "bq-log-alerting" {
   function_timeout_s             = var.function_timeout
   function_available_memory_mb   = var.function_memory
   topic_name                     = "bq-alerts-function-trigger"
-  region                         = var.region
+  region                         = var.function_region
 
   function_environment_variables = {
     CSCC_SOURCE     = local.actual_source_name

--- a/modules/bq-log-alerting/variables.tf
+++ b/modules/bq-log-alerting/variables.tf
@@ -20,12 +20,12 @@ variable "org_id" {
 }
 
 variable "function_region" {
-  description = "Region for the Cloud function resources."
+  description = "Region for the Cloud function resources. See https://cloud.google.com/functions/docs/locations for valid values."
   type        = string
 }
 
 variable "bigquery_location" {
-  description = "Location for BigQuery resources."
+  description = "Location for BigQuery resources. See https://cloud.google.com/bigquery/docs/locations for valid values."
   type        = string
   default     = "US"
 }

--- a/modules/bq-log-alerting/variables.tf
+++ b/modules/bq-log-alerting/variables.tf
@@ -19,9 +19,15 @@ variable "org_id" {
   type        = string
 }
 
-variable "region" {
-  description = "Region for BigQuery resources."
+variable "function_region" {
+  description = "Region for the Cloud function resources."
   type        = string
+}
+
+variable "bigquery_location" {
+  description = "Location for BigQuery resources."
+  type        = string
+  default     = "US"
 }
 
 variable "source_name" {

--- a/modules/bq-log-alerting/versions.tf
+++ b/modules/bq-log-alerting/versions.tf
@@ -15,5 +15,12 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">= 0.13"
+  required_providers {
+
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.53"
+    }
+  }
 }

--- a/test/fixtures/bq-log-alerting/main.tf
+++ b/test/fixtures/bq-log-alerting/main.tf
@@ -17,7 +17,8 @@
 module "bq-log-alerting" {
   source               = "../../../modules/bq-log-alerting"
   org_id               = var.parent_resource_organization
-  region               = var.region
+  function_region      = var.function_region
+  bigquery_location    = var.bigquery_location
   source_name          = var.source_name
   logging_project      = var.project_id
   job_schedule         = var.job_schedule

--- a/test/fixtures/bq-log-alerting/outputs.tf
+++ b/test/fixtures/bq-log-alerting/outputs.tf
@@ -54,9 +54,9 @@ output "dry_run" {
   description = "Enable dry_run execution of the Cloud Function. If is true it will just print the object the would be converted as a finding"
 }
 
-output "region" {
-  value       = var.region
-  description = "Region for BigQuery resources."
+output "function_region" {
+  value       = var.function_region
+  description = "Region for the Cloud function resources."
 }
 
 output "org_id" {

--- a/test/fixtures/bq-log-alerting/outputs.tf
+++ b/test/fixtures/bq-log-alerting/outputs.tf
@@ -56,7 +56,7 @@ output "dry_run" {
 
 output "function_region" {
   value       = var.function_region
-  description = "Region for the Cloud function resources."
+  description = "Region for the Cloud function resources. See https://cloud.google.com/functions/docs/locations for valid values."
 }
 
 output "org_id" {

--- a/test/fixtures/bq-log-alerting/variables.tf
+++ b/test/fixtures/bq-log-alerting/variables.tf
@@ -19,10 +19,16 @@ variable "parent_resource_organization" {
   type        = string
 }
 
-variable "region" {
-  description = "Region for BigQuery resources."
+variable "function_region" {
+  description = "Region for the Cloud function resources."
   type        = string
   default     = "us-central1"
+}
+
+variable "bigquery_location" {
+  description = "Location for BigQuery resources."
+  type        = string
+  default     = "US"
 }
 
 variable "source_name" {

--- a/test/fixtures/bq-log-alerting/variables.tf
+++ b/test/fixtures/bq-log-alerting/variables.tf
@@ -20,13 +20,13 @@ variable "parent_resource_organization" {
 }
 
 variable "function_region" {
-  description = "Region for the Cloud function resources."
+  description = "Region for the Cloud function resources. See https://cloud.google.com/functions/docs/locations for valid values."
   type        = string
   default     = "us-central1"
 }
 
 variable "bigquery_location" {
-  description = "Location for BigQuery resources."
+  description = "Location for BigQuery resources. See https://cloud.google.com/bigquery/docs/locations for valid values."
   type        = string
   default     = "US"
 }

--- a/test/integration/bq-log-alerting/controls/gcloud.rb
+++ b/test/integration/bq-log-alerting/controls/gcloud.rb
@@ -15,13 +15,13 @@
 cloud_scheduler_job_name = attribute('cloud_scheduler_job_name')
 org_id = attribute('org_id')
 logging_project = attribute('logging_project')
-region = attribute('region')
+function_region = attribute('function_region')
 pubsub_topic_name = attribute('pubsub_topic_name')
 job_schedule = attribute('job_schedule')
 source_name = attribute('source_name')
 
 job_name = 'bq-alerts-event-trigger'
-complete_job_name = "projects/#{logging_project}/locations/#{region}/jobs/#{job_name}"
+complete_job_name = "projects/#{logging_project}/locations/#{function_region}/jobs/#{job_name}"
 
 topic_name = "projects/#{logging_project}/topics/#{pubsub_topic_name}"
 

--- a/test/integration/bq-log-alerting/controls/gcp.rb
+++ b/test/integration/bq-log-alerting/controls/gcp.rb
@@ -17,7 +17,7 @@ source_name = attribute('source_name')
 cf_service_account_email = attribute('cf_service_account_email')
 logging_project = attribute('logging_project')
 dry_run = attribute('dry_run') ? 'true' : 'false'
-region = attribute('region')
+function_region = attribute('function_region')
 org_id = attribute('org_id')
 
 project_role = 'roles/bigquery.admin'
@@ -65,7 +65,7 @@ control 'gcp' do
 
   describe google_cloudfunctions_cloud_function(
     project: logging_project,
-    location: region,
+    location: function_region,
     name: cf_name
   ) do
     it { should exist }

--- a/test/integration/bq-log-alerting/inspec.yml
+++ b/test/integration/bq-log-alerting/inspec.yml
@@ -22,7 +22,7 @@ attributes:
   - name: dry_run
     required: true
     type: boolean
-  - name: region
+  - name: function_region
     required: true
     type: string
   - name: org_id


### PR DESCRIPTION
The changes for module BigQuery Log Alerting  in this PR are:

- fixes in the documentation to make the requirements more clear specially regarding the use of a service account to deploy the module.
- the variable `region` has been split in two new variables `bigquery_location` and `function_region`.