### PR TITLE
Fixing subscriber role

### DIFF
--- a/modules/pubsub/main.tf
+++ b/modules/pubsub/main.tf
@@ -74,11 +74,11 @@ resource "google_service_account" "pubsub_subscriber" {
 }
 
 resource "google_pubsub_subscription_iam_member" "pubsub_subscriber_role" {
-  count   = var.create_subscriber ? 1 : 0
-  role    = "roles/pubsub.subscriber"
-  project = var.project_id
-  subscription  = local.pubsub_subscription  
-  member  = "serviceAccount:${google_service_account.pubsub_subscriber[0].email}"
+  count        = var.create_subscriber ? 1 : 0
+  role         = "roles/pubsub.subscriber"
+  project      = var.project_id
+  subscription = local.pubsub_subscription
+  member       = "serviceAccount:${google_service_account.pubsub_subscriber[0].email}"
 }
 
 resource "google_pubsub_topic_iam_member" "pubsub_viewer_role" {

--- a/modules/pubsub/main.tf
+++ b/modules/pubsub/main.tf
@@ -73,11 +73,11 @@ resource "google_service_account" "pubsub_subscriber" {
   project      = var.project_id
 }
 
-resource "google_pubsub_topic_iam_member" "pubsub_subscriber_role" {
+resource "google_pubsub_subscription_iam_member" "pubsub_subscriber_role" {
   count   = var.create_subscriber ? 1 : 0
   role    = "roles/pubsub.subscriber"
   project = var.project_id
-  topic   = local.topic_name
+  subscription  = local.pubsub_subscription  
   member  = "serviceAccount:${google_service_account.pubsub_subscriber[0].email}"
 }
 


### PR DESCRIPTION
Upon testing, we could not pull pub/sub messages when the subscriber role was applied to the topic. Once the account has subscriber role on the subscription, we were immediately able to pull messages (to Splunk).

Change the resource from `google_pubsub_topic_iam_member` to `google_pubsub_subscription_iam_member`  (and appropriate parameter (from topic to subscription)

Closes #91 