### PR TITLE
Fix for day to ms conversion

### DIFF
--- a/modules/bigquery/main.tf
+++ b/modules/bigquery/main.tf
@@ -44,7 +44,7 @@ resource "google_bigquery_dataset" "dataset" {
   location                    = var.location
   description                 = var.description
   delete_contents_on_destroy  = var.delete_contents_on_destroy
-  default_table_expiration_ms = var.expiration_days == null ? null : var.expiration_days * 8.64 * pow(10, 7)
+  default_table_expiration_ms = var.expiration_days == null ? null : var.expiration_days * 864 * pow(10, 5)
   labels                      = var.labels
 
   dynamic "default_encryption_configuration" {


### PR DESCRIPTION
Fix for the https://github.com/terraform-google-modules/terraform-google-log-export/issues/105

Using floating number caused the issue

> 90 * 8.64 * pow(10,7)
7776000000.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006

New Change will resolve this issue

> 90 * 864 * pow(10,5)
7776000000