### PR TITLE
fix:logbucket sink in same project

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -69,6 +69,21 @@ steps:
     - go-verify-logbucket-org
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'cft test run TestLogBucketOrgModule --stage teardown --verbose']
+- id: go-apply-logbucket-project
+  waitFor:
+    - init-all
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestLogBucketProjectModule --stage apply --verbose']
+- id: go-verify-logbucket-project
+  waitFor:
+    - go-apply-logbucket-org
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestLogBucketProjectModule --stage verify --verbose']
+- id: go-teardown-logbucket-project
+  waitFor:
+    - go-verify-logbucket-project
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestLogBucketProjectModule --stage teardown --verbose']
 tags:
 - 'ci'
 - 'integration'

--- a/examples/logbucket/project/README.md
+++ b/examples/logbucket/project/README.md
@@ -8,7 +8,7 @@ These examples configures a project-level log sink that feeds a logging log buck
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | parent\_resource\_project | The ID of the project in which the log export will be created. | `string` | n/a | yes |
-| project\_id | The ID of the project in which log bucket destination will be created. | `string` | n/a | yes |
+| project\_destination\_logbkt\_id | The ID of the project in which log bucket destination will be created. | `string` | n/a | yes |
 
 ## Outputs
 
@@ -20,7 +20,11 @@ These examples configures a project-level log sink that feeds a logging log buck
 | log\_bucket\_project\_same\_project\_example | The project where the log bucket is created for sink and logbucket in same project example. |
 | log\_sink\_destination\_uri | A fully qualified URI for the log sink. |
 | log\_sink\_destination\_uri\_same\_project\_example | A fully qualified URI for the log sink for sink and logbucket in same project example. |
-| log\_sink\_folder\_id\_same\_project\_example | The folder id where the log sink is created for sink and logbucket in same project example. |
 | log\_sink\_project\_id | The project id where the log sink is created. |
+| log\_sink\_project\_id\_same\_project\_example | The project id where the log sink is created for sink and logbucket in same project example. |
+| log\_sink\_resource\_name | The resource name of the log sink that was created. |
+| log\_sink\_resource\_name\_same\_project\_example | The resource name of the log sink that was created in same project example. |
+| log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. |
+| log\_sink\_writer\_identity\_same\_project\_example | The service account in same project example that logging uses to write log entries to the destination. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/logbucket/project/README.md
+++ b/examples/logbucket/project/README.md
@@ -1,0 +1,26 @@
+# Log Export: Log Bucket destination at Folder level
+
+These examples configures a project-level log sink that feeds a logging log bucket destination with log bucket and log sink in the same project and in separated projects.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| parent\_resource\_project | The ID of the project in which the log export will be created. | `string` | n/a | yes |
+| project\_id | The ID of the project in which log bucket destination will be created. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| log\_bucket\_name | The name for the log bucket. |
+| log\_bucket\_name\_same\_project\_example | The name for the log bucket for sink and logbucket in same project example. |
+| log\_bucket\_project | The project where the log bucket is created. |
+| log\_bucket\_project\_same\_project\_example | The project where the log bucket is created for sink and logbucket in same project example. |
+| log\_sink\_destination\_uri | A fully qualified URI for the log sink. |
+| log\_sink\_destination\_uri\_same\_project\_example | A fully qualified URI for the log sink for sink and logbucket in same project example. |
+| log\_sink\_folder\_id\_same\_project\_example | The folder id where the log sink is created for sink and logbucket in same project example. |
+| log\_sink\_project\_id | The project id where the log sink is created. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/logbucket/project/main.tf
+++ b/examples/logbucket/project/main.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+resource "random_string" "suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
 module "log_export" {
   source                 = "../../../"
   destination_uri        = module.destination.destination_uri
@@ -27,7 +33,7 @@ module "log_export" {
 module "destination" {
   source                   = "../../..//modules/logbucket"
   project_id               = var.project_destination_logbkt_id
-  name                     = "logbucket_project_from_${var.parent_resource_project}"
+  name                     = "logbucket_from_other_project_${random_string.suffix.result}"
   location                 = "global"
   log_sink_writer_identity = module.log_export.writer_identity
 }
@@ -48,7 +54,7 @@ module "log_export_same_project_example" {
 module "destination_same_project_example" {
   source                        = "../../..//modules/logbucket"
   project_id                    = var.project_destination_logbkt_id
-  name                          = "logbucket_project_from_${var.project_destination_logbkt_id}"
+  name                          = "logbucket_from_same_project_${random_string.suffix.result}"
   location                      = "global"
   log_sink_writer_identity      = module.log_export_same_project_example.writer_identity
   grant_write_permission_on_bkt = false

--- a/examples/logbucket/project/main.tf
+++ b/examples/logbucket/project/main.tf
@@ -14,23 +14,11 @@
  * limitations under the License.
  */
 
-resource "random_string" "suffix" {
-  length  = 4
-  upper   = false
-  special = false
-}
-
-resource "random_string" "suffix_same_project_example" {
-  length  = 4
-  upper   = false
-  special = false
-}
-
 module "log_export" {
   source                 = "../../../"
   destination_uri        = module.destination.destination_uri
   filter                 = "resource.type = gce_instance"
-  log_sink_name          = "logbucket_project_${random_string.suffix.result}"
+  log_sink_name          = "logbucket_other_project"
   parent_resource_id     = var.parent_resource_project
   parent_resource_type   = "project"
   unique_writer_identity = true
@@ -38,8 +26,8 @@ module "log_export" {
 
 module "destination" {
   source                   = "../../..//modules/logbucket"
-  project_id               = var.project_id
-  name                     = "logbucket_project_${random_string.suffix.result}"
+  project_id               = var.project_destination_logbkt_id
+  name                     = "logbucket_project_from_${var.parent_resource_project}"
   location                 = "global"
   log_sink_writer_identity = module.log_export.writer_identity
 }
@@ -51,17 +39,18 @@ module "log_export_same_project_example" {
   source                 = "../../../"
   destination_uri        = module.destination_same_project_example.destination_uri
   filter                 = "resource.type = gce_instance"
-  log_sink_name          = "logbucket_folder_${random_string.suffix_same_project_example.result}"
-  parent_resource_id     = var.project_id
+  log_sink_name          = "logbucket_same_project"
+  parent_resource_id     = var.project_destination_logbkt_id
   parent_resource_type   = "project"
   unique_writer_identity = true
 }
 
 module "destination_same_project_example" {
-  source                          = "../../..//modules/logbucket"
-  project_id                      = var.project_id
-  name                            = "logbucket_project_${random_string.suffix.result}"
-  location                        = "global"
-  log_sink_writer_identity        = module.log_export_same_project_example.writer_identity
-  sink_and_bucket_in_same_project = true
+  source                        = "../../..//modules/logbucket"
+  project_id                    = var.project_destination_logbkt_id
+  name                          = "logbucket_project_from_${var.project_destination_logbkt_id}"
+  location                      = "global"
+  log_sink_writer_identity      = module.log_export_same_project_example.writer_identity
+  grant_write_permission_on_bkt = false
+  retention_days                = 20
 }

--- a/examples/logbucket/project/main.tf
+++ b/examples/logbucket/project/main.tf
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "random_string" "suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+resource "random_string" "suffix_same_project_example" {
+  length  = 4
+  upper   = false
+  special = false
+}
+
+module "log_export" {
+  source                 = "../../../"
+  destination_uri        = module.destination.destination_uri
+  filter                 = "resource.type = gce_instance"
+  log_sink_name          = "logbucket_project_${random_string.suffix.result}"
+  parent_resource_id     = var.parent_resource_project
+  parent_resource_type   = "project"
+  unique_writer_identity = true
+}
+
+module "destination" {
+  source                   = "../../..//modules/logbucket"
+  project_id               = var.project_id
+  name                     = "logbucket_project_${random_string.suffix.result}"
+  location                 = "global"
+  log_sink_writer_identity = module.log_export.writer_identity
+}
+
+#-------------------------------------#
+# Log Bucket and Sink in same project #
+#-------------------------------------#
+module "log_export_same_project_example" {
+  source                 = "../../../"
+  destination_uri        = module.destination_same_project_example.destination_uri
+  filter                 = "resource.type = gce_instance"
+  log_sink_name          = "logbucket_folder_${random_string.suffix_same_project_example.result}"
+  parent_resource_id     = var.project_id
+  parent_resource_type   = "project"
+  unique_writer_identity = true
+}
+
+module "destination_same_project_example" {
+  source                          = "../../..//modules/logbucket"
+  project_id                      = var.project_id
+  name                            = "logbucket_project_${random_string.suffix.result}"
+  location                        = "global"
+  log_sink_writer_identity        = module.log_export_same_project_example.writer_identity
+  sink_and_bucket_in_same_project = true
+}

--- a/examples/logbucket/project/outputs.tf
+++ b/examples/logbucket/project/outputs.tf
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "log_bucket_project" {
+  description = "The project where the log bucket is created."
+  value       = module.destination.project
+}
+
+output "log_bucket_name" {
+  description = "The name for the log bucket."
+  value       = module.destination.resource_name
+}
+
+output "log_sink_project_id" {
+  description = "The project id where the log sink is created."
+  value       = module.log_export.parent_resource_id
+}
+
+output "log_sink_destination_uri" {
+  description = "A fully qualified URI for the log sink."
+  value       = module.destination.destination_uri
+}
+
+#-------------------------------------#
+# Log Bucket and Sink in same project #
+#-------------------------------------#
+output "log_bucket_project_same_project_example" {
+  description = "The project where the log bucket is created for sink and logbucket in same project example."
+  value       = module.destination_same_project_example.project
+}
+
+output "log_bucket_name_same_project_example" {
+  description = "The name for the log bucket for sink and logbucket in same project example."
+  value       = module.destination_same_project_example.resource_name
+}
+
+output "log_sink_folder_id_same_project_example" {
+  description = "The folder id where the log sink is created for sink and logbucket in same project example."
+  value       = module.log_export_same_project_example.parent_resource_id
+}
+
+output "log_sink_destination_uri_same_project_example" {
+  description = "A fully qualified URI for the log sink for sink and logbucket in same project example."
+  value       = module.destination_same_project_example.destination_uri
+}

--- a/examples/logbucket/project/outputs.tf
+++ b/examples/logbucket/project/outputs.tf
@@ -34,6 +34,17 @@ output "log_sink_destination_uri" {
   value       = module.destination.destination_uri
 }
 
+output "log_sink_resource_name" {
+  description = "The resource name of the log sink that was created."
+  value       = module.log_export.log_sink_resource_name
+}
+
+output "log_sink_writer_identity" {
+  description = "The service account that logging uses to write log entries to the destination."
+  value       = module.log_export.writer_identity
+}
+
+
 #-------------------------------------#
 # Log Bucket and Sink in same project #
 #-------------------------------------#
@@ -47,12 +58,22 @@ output "log_bucket_name_same_project_example" {
   value       = module.destination_same_project_example.resource_name
 }
 
-output "log_sink_folder_id_same_project_example" {
-  description = "The folder id where the log sink is created for sink and logbucket in same project example."
+output "log_sink_project_id_same_project_example" {
+  description = "The project id where the log sink is created for sink and logbucket in same project example."
   value       = module.log_export_same_project_example.parent_resource_id
 }
 
 output "log_sink_destination_uri_same_project_example" {
   description = "A fully qualified URI for the log sink for sink and logbucket in same project example."
   value       = module.destination_same_project_example.destination_uri
+}
+
+output "log_sink_resource_name_same_project_example" {
+  description = "The resource name of the log sink that was created in same project example."
+  value       = module.log_export_same_project_example.log_sink_resource_name
+}
+
+output "log_sink_writer_identity_same_project_example" {
+  description = "The service account in same project example that logging uses to write log entries to the destination."
+  value       = module.log_export_same_project_example.writer_identity
 }

--- a/examples/logbucket/project/variables.tf
+++ b/examples/logbucket/project/variables.tf
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-variable "project_id" {
+variable "project_destination_logbkt_id" {
   description = "The ID of the project in which log bucket destination will be created."
   type        = string
 }

--- a/examples/logbucket/project/variables.tf
+++ b/examples/logbucket/project/variables.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which log bucket destination will be created."
+  type        = string
+}
+
+variable "parent_resource_project" {
+  description = "The ID of the project in which the log export will be created."
+  type        = string
+}

--- a/examples/logbucket/project/versions.tf
+++ b/examples/logbucket/project/versions.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
+}

--- a/modules/logbucket/README.md
+++ b/modules/logbucket/README.md
@@ -37,12 +37,12 @@ module "destination" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| grant\_write\_permission\_on\_bkt | (Optional) Indicates whether the module is responsible for granting write permission on the logbucket. This permission will be given by default, but if the user wants, this module can skip this step. This is the case when the sink route logs to a log bucket in the same Cloud project, no new service account will be created and this module will need to bypass granting permissions. | `bool` | `true` | no |
 | location | The location of the log bucket. | `string` | `"global"` | no |
 | log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | `string` | n/a | yes |
 | name | The name of the log bucket to be created and used for log entries matching the filter. | `string` | n/a | yes |
 | project\_id | The ID of the project in which the log bucket will be created. | `string` | n/a | yes |
 | retention\_days | The number of days data should be retained for the log bucket. | `number` | `30` | no |
-| sink\_and\_bucket\_in\_same\_project | (Optional) Indicates if the sink and logging bucket are in the same project. When the sink route logs between Logging buckets in the same Cloud project, no new service account need to be created. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/logbucket/README.md
+++ b/modules/logbucket/README.md
@@ -42,6 +42,7 @@ module "destination" {
 | name | The name of the log bucket to be created and used for log entries matching the filter. | `string` | n/a | yes |
 | project\_id | The ID of the project in which the log bucket will be created. | `string` | n/a | yes |
 | retention\_days | The number of days data should be retained for the log bucket. | `number` | `30` | no |
+| sink\_and\_bucket\_in\_same\_project | (Optional) Indicates if the sink and logging bucket are in the same project. When the sink route logs between Logging buckets in the same Cloud project, no new service account need to be created. | `bool` | `false` | no |
 
 ## Outputs
 

--- a/modules/logbucket/main.tf
+++ b/modules/logbucket/main.tf
@@ -43,6 +43,8 @@ resource "google_logging_project_bucket_config" "bucket" {
 # Service account IAM membership #
 #--------------------------------#
 resource "google_project_iam_member" "logbucket_sink_member" {
+  count = !var.sink_and_bucket_in_same_project ? 1 : 0
+
   project = google_logging_project_bucket_config.bucket.project
   role    = "roles/logging.bucketWriter"
   member  = var.log_sink_writer_identity

--- a/modules/logbucket/main.tf
+++ b/modules/logbucket/main.tf
@@ -43,7 +43,7 @@ resource "google_logging_project_bucket_config" "bucket" {
 # Service account IAM membership #
 #--------------------------------#
 resource "google_project_iam_member" "logbucket_sink_member" {
-  count = !var.sink_and_bucket_in_same_project ? 1 : 0
+  count = var.grant_write_permission_on_bkt ? 1 : 0
 
   project = google_logging_project_bucket_config.bucket.project
   role    = "roles/logging.bucketWriter"

--- a/modules/logbucket/outputs.tf
+++ b/modules/logbucket/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/logbucket/variables.tf
+++ b/modules/logbucket/variables.tf
@@ -41,8 +41,8 @@ variable "retention_days" {
   default     = 30
 }
 
-variable "sink_and_bucket_in_same_project" {
-  description = "(Optional) Indicates if the sink and logging bucket are in the same project. When the sink route logs between Logging buckets in the same Cloud project, no new service account need to be created."
+variable "grant_write_permission_on_bkt" {
+  description = "(Optional) Indicates whether the module is responsible for granting write permission on the logbucket. This permission will be given by default, but if the user wants, this module can skip this step. This is the case when the sink route logs to a log bucket in the same Cloud project, no new service account will be created and this module will need to bypass granting permissions."
   type        = bool
-  default     = false
+  default     = true
 }

--- a/modules/logbucket/variables.tf
+++ b/modules/logbucket/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,4 +39,10 @@ variable "retention_days" {
   description = "The number of days data should be retained for the log bucket."
   type        = number
   default     = 30
+}
+
+variable "sink_and_bucket_in_same_project" {
+  description = "(Optional) Indicates if the sink and logging bucket are in the same project. When the sink route logs between Logging buckets in the same Cloud project, no new service account need to be created."
+  type        = bool
+  default     = false
 }

--- a/test/integration/logbucket-project/logbucket_project_test.go
+++ b/test/integration/logbucket-project/logbucket_project_test.go
@@ -1,0 +1,104 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logbucket_project
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogBucketProjectModule(t *testing.T) {
+
+	const logApiFdqm = "logging.googleapis.com"
+	const RETENTION_DAYS = 20
+	const SAMEPROJ_LOGSINK_WRITER_IDENTITY string = ""
+	const ROLE_BUCKET_WRITER string = "roles/logging.bucketWriter"
+
+	insSimpleT := tft.NewTFBlueprintTest(t,
+		tft.WithTFDir("../../../examples/logbucket/project"),
+	)
+	insSimpleT.DefineVerify(func(assert *assert.Assertions) {
+		insSimpleT.DefaultVerify(assert)
+
+		//*******************************
+		// Bucket on other project test *
+		//*******************************
+		projectId := insSimpleT.GetStringOutput("log_bucket_project")
+		logBucketName := insSimpleT.GetStringOutput("log_bucket_name")
+		logBucketDestinationProjId := insSimpleT.GetStringOutput("log_bucket_project_same_project_example")
+		logSinkProjectId := insSimpleT.GetStringOutput("log_sink_project_id")
+		logSinkDestination := insSimpleT.GetStringOutput("log_sink_destination_uri")
+		logSinkName := insSimpleT.GetStringOutput("log_sink_resource_name")
+		logSinkWriterIdentity := insSimpleT.GetStringOutput("log_sink_writer_identity")
+
+		logBucketDetails := gcloud.Runf(t, fmt.Sprintf("logging buckets describe %s --location=%s --project=%s", logBucketName, "global", projectId))
+
+		// assert log bucket name, retention days & location
+		assert.Equal(logSinkDestination[len(logApiFdqm)+1:], logBucketDetails.Get("name").String(), "log bucket name should match")
+		assert.Equal(int64(30), logBucketDetails.Get("retentionDays").Int(), "retention days should match")
+
+		logSinkDetails := gcloud.Runf(t, fmt.Sprintf("logging sinks describe %s --project=%s", logSinkName, logSinkProjectId))
+
+		// assert log sink name, destination & filter
+		assert.Equal(logSinkDestination, logSinkDetails.Get("destination").String(), "log sink destination should match")
+		assert.Equal("resource.type = gce_instance", logSinkDetails.Get("filter").String(), "log sink filter should match")
+		assert.Equal(logSinkWriterIdentity, logSinkDetails.Get("writerIdentity").String(), "log sink writerIdentity should not be empty")
+
+
+		//**********************************
+		// Bucket on the same project test *
+		//**********************************
+		sameProjId := insSimpleT.GetStringOutput("log_bucket_project_same_project_example")
+		sameProjLogBucketName := insSimpleT.GetStringOutput("log_bucket_name_same_project_example")
+		sameProjLogSinkProjectId := insSimpleT.GetStringOutput("log_sink_project_id_same_project_example")
+		sameProjLogSinkDestination := insSimpleT.GetStringOutput("log_sink_destination_uri_same_project_example")
+		sameProjLogSinkName := insSimpleT.GetStringOutput("log_sink_resource_name_same_project_example")
+
+		assert.NotEqual(sameProjId, "a", "log sink destination should match")
+		assert.NotEqual(sameProjLogBucketName, "", "log sink destination should match")
+		assert.NotEqual(sameProjLogSinkProjectId, "", "log sink destination should match")
+		assert.NotEqual(sameProjLogSinkDestination, "", "log sink destination should match")
+
+		sameProjLogBucketDetails := gcloud.Runf(t, fmt.Sprintf("logging buckets describe %s --location=%s --project=%s", sameProjLogBucketName, "global", sameProjId))
+
+		// assert log bucket name, retention days & location
+		assert.Equal(sameProjLogSinkDestination[len(logApiFdqm)+1:], sameProjLogBucketDetails.Get("name").String(), "log bucket name should match")
+		assert.Equal(int64(RETENTION_DAYS), sameProjLogBucketDetails.Get("retentionDays").Int(), "retention days should match")
+
+		sameProjLogSinkDetails := gcloud.Runf(t, fmt.Sprintf("logging sinks describe %s --project=%s", sameProjLogSinkName, sameProjLogSinkProjectId))
+
+		// assert log sink name, destination & filter
+		assert.Equal(sameProjLogSinkDestination, sameProjLogSinkDetails.Get("destination").String(), "log sink destination should match")
+		assert.Equal("resource.type = gce_instance", sameProjLogSinkDetails.Get("filter").String(), "log sink filter should match")
+		assert.Equal(SAMEPROJ_LOGSINK_WRITER_IDENTITY, sameProjLogSinkDetails.Get("writerIdentity").String(), "log sink writerIdentity should not be empty")
+
+
+		//***************************
+		// Test SAs and Permissions *
+		//***************************
+		projPermissionsDetails := gcloud.Runf(t, fmt.Sprintf("projects get-iam-policy %s", logBucketDestinationProjId))
+		listMembers := utils.GetResultStrSlice(projPermissionsDetails.Get("bindings.#(role==\""+ ROLE_BUCKET_WRITER +"\").members").Array())
+
+		// assert sink writer identity service account permission
+		assert.Contains(listMembers, logSinkWriterIdentity, "log sink writer identity permission should match")
+		assert.Equal(int(1), len(listMembers), "only one writer identity should have logbucket write permission")
+	})
+	insSimpleT.Test()
+}

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -87,10 +87,24 @@ resource "google_service_account" "int_test" {
   display_name = "ci-account"
 }
 
+resource "google_service_account" "int_test_logbkt" {
+  project      = module.project_destination_logbkt.project_id
+  account_id   = "ci-account"
+  display_name = "ci-account"
+}
+
 resource "google_project_iam_member" "int_test" {
   for_each = toset(local.log_export_required_roles)
 
   project = module.project.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.int_test.email}"
+}
+
+resource "google_project_iam_member" "int_test_logbkt" {
+  for_each = toset(local.log_export_required_roles)
+
+  project = module.project_destination_logbkt.project_id
   role    = each.value
   member  = "serviceAccount:${google_service_account.int_test.email}"
 }
@@ -139,6 +153,7 @@ resource "null_resource" "wait_permissions" {
     google_billing_account_iam_member.int_test,
     google_folder_iam_member.int_test,
     google_organization_iam_member.int_test,
-    google_project_iam_member.int_test
+    google_project_iam_member.int_test,
+    google_project_iam_member.int_test_logbkt
   ]
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -41,12 +41,41 @@ module "project" {
   ]
 }
 
+module "project_destination_logbkt" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 10.0"
+
+  name              = "ci-destination-logbkt"
+  random_project_id = true
+  org_id            = var.org_id
+  folder_id         = var.folder_id
+  billing_account   = var.billing_account
+
+  activate_apis = [
+    "cloudapis.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "cloudscheduler.googleapis.com",
+    "securitycenter.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "oslogin.googleapis.com",
+    "compute.googleapis.com",
+    "pubsub.googleapis.com",
+    "storage-component.googleapis.com",
+    "storage-api.googleapis.com",
+    "iam.googleapis.com",
+    "cloudbilling.googleapis.com"
+  ]
+}
+
 resource "null_resource" "wait_apis" {
   # Adding a pause as a workaround for of the provider issue
   # https://github.com/terraform-providers/terraform-provider-google/issues/1131
   provisioner "local-exec" {
     command = "echo sleep 120s for APIs to get enabled; sleep 120"
   }
-  depends_on = [module.project.project_id]
+  depends_on = [
+    module.project.project_id,
+    module.project_destination_logbkt.project_id
+  ]
 }
-

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -38,3 +38,7 @@ output "parent_resource_billing_account" {
 output "parent_resource_organization" {
   value = var.org_id
 }
+
+output "project_destination_logbkt_id" {
+  value = module.project_destination_logbkt.project_id
+}


### PR DESCRIPTION
Fix for #116 issue.
PR changes:
- New variable `grant_write_permission_on_bkt` on logbucket destination module that enables the user to not grant logbucket write permission, that is the use case when sink and logbucket are in the same project - [reference](https://cloud.google.com/logging/docs/export/configure_export_v2#dest-auth:~:text=If%20you%27re%20using%20a%20sink%20to%20route%20logs%20between%20Logging%20buckets%20in%20the%20same%20Cloud%20project%2C%20no%20new%20service%20account%20is%20created%3B%20the%20sink%20works%20without%20the%20unique%20writer%20identity)
- Example of usage logbucket in projects
- Integrated test of logbucket with projects
