### PR TITLE
fix: update version constraints for TPG v5

### DIFF
--- a/examples/bigquery/billing_account/versions.tf
+++ b/examples/bigquery/billing_account/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
   }
 }

--- a/examples/bigquery/billing_account/versions.tf
+++ b/examples/bigquery/billing_account/versions.tf
@@ -18,8 +18,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
   }
 }

--- a/examples/bigquery/folder/versions.tf
+++ b/examples/bigquery/folder/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/bigquery/folder/versions.tf
+++ b/examples/bigquery/folder/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/bigquery/organization/versions.tf
+++ b/examples/bigquery/organization/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/bigquery/organization/versions.tf
+++ b/examples/bigquery/organization/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/bigquery/project/versions.tf
+++ b/examples/bigquery/project/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/bigquery/project/versions.tf
+++ b/examples/bigquery/project/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/bq-log-alerting/versions.tf
+++ b/examples/bq-log-alerting/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
   }
 }

--- a/examples/bq-log-alerting/versions.tf
+++ b/examples/bq-log-alerting/versions.tf
@@ -18,8 +18,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
   }
 }

--- a/examples/datadog-sink/versions.tf
+++ b/examples/datadog-sink/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     local = {
       source = "hashicorp/local"

--- a/examples/datadog-sink/versions.tf
+++ b/examples/datadog-sink/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     local = {
       source = "hashicorp/local"

--- a/examples/logbucket/folder/versions.tf
+++ b/examples/logbucket/folder/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/logbucket/folder/versions.tf
+++ b/examples/logbucket/folder/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/logbucket/organization/versions.tf
+++ b/examples/logbucket/organization/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/logbucket/organization/versions.tf
+++ b/examples/logbucket/organization/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/logbucket/project/versions.tf
+++ b/examples/logbucket/project/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/logbucket/project/versions.tf
+++ b/examples/logbucket/project/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/project/project/versions.tf
+++ b/examples/project/project/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/project/project/versions.tf
+++ b/examples/project/project/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/pubsub/billing_account/versions.tf
+++ b/examples/pubsub/billing_account/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
   }
 }

--- a/examples/pubsub/billing_account/versions.tf
+++ b/examples/pubsub/billing_account/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
   }
 }

--- a/examples/pubsub/folder/versions.tf
+++ b/examples/pubsub/folder/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/pubsub/folder/versions.tf
+++ b/examples/pubsub/folder/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/pubsub/organization/versions.tf
+++ b/examples/pubsub/organization/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/pubsub/organization/versions.tf
+++ b/examples/pubsub/organization/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/pubsub/project/versions.tf
+++ b/examples/pubsub/project/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/pubsub/project/versions.tf
+++ b/examples/pubsub/project/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/splunk-sink/versions.tf
+++ b/examples/splunk-sink/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
   }
 }

--- a/examples/splunk-sink/versions.tf
+++ b/examples/splunk-sink/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
   }
 }

--- a/examples/storage/billing_account/versions.tf
+++ b/examples/storage/billing_account/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
   }
 }

--- a/examples/storage/billing_account/versions.tf
+++ b/examples/storage/billing_account/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
   }
 }

--- a/examples/storage/folder/versions.tf
+++ b/examples/storage/folder/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/storage/folder/versions.tf
+++ b/examples/storage/folder/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/storage/organization/versions.tf
+++ b/examples/storage/organization/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/storage/organization/versions.tf
+++ b/examples/storage/organization/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/storage/project/versions.tf
+++ b/examples/storage/project/versions.tf
@@ -19,8 +19,7 @@ terraform {
   required_version = ">= 0.13"
   required_providers {
     google = {
-      source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      source = "hashicorp/google"
     }
     random = {
       source = "hashicorp/random"

--- a/examples/storage/project/versions.tf
+++ b/examples/storage/project/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 3.53, < 6"
     }
     random = {
       source = "hashicorp/random"

--- a/modules/storage/versions.tf
+++ b/modules/storage/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.42, < 5.0"
+      version = ">= 3.53, < 6"
     }
   }
 

--- a/modules/storage/versions.tf
+++ b/modules/storage/versions.tf
@@ -20,7 +20,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 6"
+      version = ">= 4.42, < 6"
     }
   }
 


### PR DESCRIPTION
Should be merged before https://github.com/terraform-google-modules/terraform-google-log-export/pull/182 to fix TPG v5 support