### PR TITLE
feat: add support for expiration policy ttl in push topic subscriptio…

### DIFF
--- a/examples/pubsub/project/main.tf
+++ b/examples/pubsub/project/main.tf
@@ -36,11 +36,12 @@ module "destination" {
   source  = "terraform-google-modules/log-export/google//modules/pubsub"
   version = "~> 8.0"
 
-  project_id               = var.project_id
-  topic_labels             = { topic_key : "topic_label" }
-  topic_name               = "pubsub-project-${random_string.suffix.result}"
-  log_sink_writer_identity = module.log_export.writer_identity
-  create_subscriber        = true
-  subscription_labels      = { subscription_key : "subscription_label" }
+  project_id                       = var.project_id
+  topic_labels                     = { topic_key : "topic_label" }
+  topic_name                       = "pubsub-project-${random_string.suffix.result}"
+  log_sink_writer_identity         = module.log_export.writer_identity
+  create_subscriber                = true
+  subscription_labels              = { subscription_key : "subscription_label" }
+  push_subscription_expiration_ttl = "300000.5s"
 }
 

--- a/modules/pubsub/README.md
+++ b/modules/pubsub/README.md
@@ -43,6 +43,7 @@ so that all dependencies are met.
 | log\_sink\_writer\_identity | The service account that logging uses to write log entries to the destination. (This is available as an output coming from the root module). | `string` | n/a | yes |
 | project\_id | The ID of the project in which the pubsub topic will be created. | `string` | n/a | yes |
 | push\_endpoint | The URL locating the endpoint to which messages should be pushed. | `string` | `""` | no |
+| push\_subscription\_expiration\_ttl | Pubsub push subscription expiration policy ttl. | `string` | `null` | no |
 | subscriber\_id | The ID to give the pubsub pull subscriber service account (optional). | `string` | `""` | no |
 | subscription\_labels | A set of key/value label pairs to assign to the pubsub subscription or pubsub push subscription. | `map(string)` | `{}` | no |
 | topic\_labels | A set of key/value label pairs to assign to the pubsub topic. | `map(string)` | `{}` | no |

--- a/modules/pubsub/main.tf
+++ b/modules/pubsub/main.tf
@@ -109,4 +109,11 @@ resource "google_pubsub_subscription" "pubsub_push_subscription" {
   push_config {
     push_endpoint = var.push_endpoint
   }
+
+  dynamic "expiration_policy" {
+    for_each = var.push_subscription_expiration_ttl == null ? [] : [1]
+    content {
+      ttl = var.push_subscription_expiration_ttl
+    }
+  }
 }

--- a/modules/pubsub/metadata.yaml
+++ b/modules/pubsub/metadata.yaml
@@ -102,6 +102,11 @@ spec:
     type: map(string)
     default: {}
     required: false
+  - name: push_subscription_expiration_ttl
+    description: The expiration policy ttl value to the pubsub push subscription.
+    type: string
+    default: null
+    required: false
   - name: topic_labels
     description: A set of key/value label pairs to assign to the pubsub topic.
     type: map(string)

--- a/modules/pubsub/variables.tf
+++ b/modules/pubsub/variables.tf
@@ -32,6 +32,12 @@ variable "subscription_labels" {
   description = "A set of key/value label pairs to assign to the pubsub subscription or pubsub push subscription."
 }
 
+variable "push_subscription_expiration_ttl" {
+  description = "Pubsub push subscription expiration policy ttl."
+  type        = string
+  default     = null
+}
+
 variable "create_push_subscriber" {
   description = "Whether to add a push configuration to the subcription. If 'true', a push subscription is created for push_endpoint"
   type        = bool


### PR DESCRIPTION
Add support for expiration policy ttl in push topic subscriptio…n in pubsub module

I have a specific use case, sometimes a subscription do not receive logs during 31days, but we would like to avoid the expiration.